### PR TITLE
4 유저 도메인 api 명세 생성

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserAccountController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserAccountController.java
@@ -16,7 +16,7 @@ import com.juwoong.opiniontrade.user.domain.Email;
 import com.juwoong.opiniontrade.user.domain.Password;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/users/account")
 public class UserAccountController {
 	private final UserAccountService userService;
 

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserAccountController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserAccountController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.juwoong.opiniontrade.user.api.request.LoginRequest;
 import com.juwoong.opiniontrade.user.api.request.SignUpRequest;
-import com.juwoong.opiniontrade.user.application.UserService;
+import com.juwoong.opiniontrade.user.application.UserAccountService;
 import com.juwoong.opiniontrade.user.application.response.LoginResponse;
 import com.juwoong.opiniontrade.user.application.response.SignUpResponse;
 import com.juwoong.opiniontrade.user.domain.Email;
@@ -17,10 +17,10 @@ import com.juwoong.opiniontrade.user.domain.Password;
 
 @RestController
 @RequestMapping("/users")
-public class UserController {
-	private final UserService userService;
+public class UserAccountController {
+	private final UserAccountService userService;
 
-	public UserController(UserService userService) {
+	public UserAccountController(UserAccountService userService) {
 		this.userService = userService;
 	}
 

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserController.java
@@ -1,0 +1,33 @@
+package com.juwoong.opiniontrade.user.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.user.api.request.SignUpRequest;
+import com.juwoong.opiniontrade.user.application.UserService;
+import com.juwoong.opiniontrade.user.application.response.SignUpResponse;
+import com.juwoong.opiniontrade.user.domain.Email;
+import com.juwoong.opiniontrade.user.domain.Password;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@PostMapping("/sign-up")
+	public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
+		Email email = signUpRequest.email();
+		Password password = signUpRequest.password();
+		SignUpResponse signUpResponse = userService.signUp(email, password);
+
+		return new ResponseEntity<>(signUpResponse, HttpStatus.CREATED);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.juwoong.opiniontrade.user.api.request.LoginRequest;
 import com.juwoong.opiniontrade.user.api.request.SignUpRequest;
 import com.juwoong.opiniontrade.user.application.UserService;
+import com.juwoong.opiniontrade.user.application.response.LoginResponse;
 import com.juwoong.opiniontrade.user.application.response.SignUpResponse;
 import com.juwoong.opiniontrade.user.domain.Email;
 import com.juwoong.opiniontrade.user.domain.Password;
@@ -29,5 +31,14 @@ public class UserController {
 		SignUpResponse signUpResponse = userService.signUp(email, password);
 
 		return new ResponseEntity<>(signUpResponse, HttpStatus.CREATED);
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+		Email email = loginRequest.email();
+		Password password = loginRequest.password();
+		LoginResponse loginResponse = userService.login(email, password);
+
+		return ResponseEntity.ok(loginResponse);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
@@ -2,6 +2,8 @@ package com.juwoong.opiniontrade.user.api;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,13 +23,21 @@ public class UserInfoController {
 		this.userInfoService = userInfoService;
 	}
 
-	@PostMapping("/profile")
-	public ResponseEntity<ProfileInfoResponse> updateProfileInfo(@RequestBody ProfileInfoRequest profileInfoRequest) {
-		Long userId = profileInfoRequest.userId();
+	@PostMapping("/{userId}/profile")
+	public ResponseEntity<ProfileInfoResponse> updateProfileInfo(
+		@PathVariable Long userId,
+		@RequestBody ProfileInfoRequest profileInfoRequest
+	) {
 		ProfileInfo profileInfo = profileInfoRequest.profileInfo();
 		ProfileInfoResponse profileInfoResponse = userInfoService.updateProfileInfo(userId, profileInfo);
 
 		return new ResponseEntity<>(profileInfoResponse, HttpStatus.CREATED);
 	}
 
+	@GetMapping("/{userId}/profile")
+	public ResponseEntity<ProfileInfoResponse> getProfileInfo(@PathVariable Long userId) {
+		ProfileInfoResponse profileInfoResponse = userInfoService.getProfileInfo(userId);
+
+		return ResponseEntity.ok(profileInfoResponse);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
@@ -1,0 +1,33 @@
+package com.juwoong.opiniontrade.user.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.user.api.request.ProfileInfoRequest;
+import com.juwoong.opiniontrade.user.application.UserInfoService;
+import com.juwoong.opiniontrade.user.application.response.ProfileInfoResponse;
+import com.juwoong.opiniontrade.user.domain.ProfileInfo;
+
+@RestController
+@RequestMapping("/users/info")
+public class UserInfoController {
+	private final UserInfoService userInfoService;
+
+	public UserInfoController(UserInfoService userInfoService) {
+		this.userInfoService = userInfoService;
+	}
+
+	@PostMapping("/profile")
+	public ResponseEntity<ProfileInfoResponse> updateProfileInfo(@RequestBody ProfileInfoRequest profileInfoRequest) {
+		Long userId = profileInfoRequest.userId();
+		ProfileInfo profileInfo = profileInfoRequest.profileInfo();
+		ProfileInfoResponse profileInfoResponse = userInfoService.updateProfileInfo(userId, profileInfo);
+
+		return new ResponseEntity<>(profileInfoResponse, HttpStatus.CREATED);
+	}
+
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
@@ -9,9 +9,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.juwoong.opiniontrade.user.api.request.ActivityInfoRequest;
 import com.juwoong.opiniontrade.user.api.request.ProfileInfoRequest;
 import com.juwoong.opiniontrade.user.application.UserInfoService;
+import com.juwoong.opiniontrade.user.application.response.ActivityInfoResponse;
 import com.juwoong.opiniontrade.user.application.response.ProfileInfoResponse;
+import com.juwoong.opiniontrade.user.domain.ActivityInfo;
 import com.juwoong.opiniontrade.user.domain.ProfileInfo;
 
 @RestController
@@ -39,5 +42,16 @@ public class UserInfoController {
 		ProfileInfoResponse profileInfoResponse = userInfoService.getProfileInfo(userId);
 
 		return ResponseEntity.ok(profileInfoResponse);
+	}
+
+	@PostMapping("/{userId}/activity")
+	public ResponseEntity<ActivityInfoResponse> updateActivityInfo(
+		@PathVariable Long userId,
+		@RequestBody ActivityInfoRequest activityInfoRequest
+	) {
+		ActivityInfo activityInfo = activityInfoRequest.activityInfo();
+		ActivityInfoResponse activityInfoResponse = userInfoService.updateActivityInfo(userId, activityInfo);
+
+		return new ResponseEntity<>(activityInfoResponse, HttpStatus.CREATED);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserInfoController.java
@@ -54,4 +54,11 @@ public class UserInfoController {
 
 		return new ResponseEntity<>(activityInfoResponse, HttpStatus.CREATED);
 	}
+
+	@GetMapping("/{userId}/activity")
+	public ResponseEntity<ActivityInfoResponse> getActivityInfo(@PathVariable Long userId) {
+		ActivityInfoResponse activityInfoResponse = userInfoService.getActivityInfo(userId);
+
+		return ResponseEntity.ok(activityInfoResponse);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
@@ -3,13 +3,18 @@ package com.juwoong.opiniontrade.user.api;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.juwoong.opiniontrade.user.api.request.FriendRequest;
 import com.juwoong.opiniontrade.user.application.UserMyService;
 import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.domain.Friend;
 
 @RestController
 @RequestMapping("/users/my")
@@ -21,10 +26,29 @@ public class UserMyController {
 	}
 
 	@GetMapping("/{userId}/friends")
-	public ResponseEntity<List<FriendResponse>> getFriends(
-		@PathVariable Long userId
-	) {
+	public ResponseEntity<List<FriendResponse>> getFriends(@PathVariable Long userId) {
 		List<FriendResponse> friendResponses = userMyService.getFriends(userId);
 		return ResponseEntity.ok(friendResponses);
+	}
+
+	@PostMapping("/{userId}/friends")
+	public ResponseEntity<FriendResponse> addFriend(
+		@PathVariable Long userId,
+		@RequestBody FriendRequest friendRequest
+	) {
+		Friend friend = friendRequest.friend();
+		FriendResponse friendResponse = userMyService.addFriend(userId, friend);
+
+		return ResponseEntity.ok(friendResponse);
+	}
+
+	@DeleteMapping("/{userId}/friends/{friendId}")
+	public ResponseEntity<Void> removeFriend(
+		@PathVariable Long userId,
+		@PathVariable Long friendId
+	) {
+		userMyService.removeFriend(friendId);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
@@ -12,11 +12,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.juwoong.opiniontrade.user.api.request.FriendRequest;
+import com.juwoong.opiniontrade.user.api.request.ScrapProductRequest;
 import com.juwoong.opiniontrade.user.api.request.ScrapSurveyRequest;
 import com.juwoong.opiniontrade.user.application.UserMyService;
 import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.application.response.ScrapProductResponse;
 import com.juwoong.opiniontrade.user.application.response.ScrapSurveyResponse;
 import com.juwoong.opiniontrade.user.domain.Friend;
+import com.juwoong.opiniontrade.user.domain.ScrapProduct;
 import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
 
 @RestController
@@ -55,13 +58,13 @@ public class UserMyController {
 		return ResponseEntity.noContent().build();
 	}
 
-	@GetMapping("/{userId}/scrap-survey")
+	@GetMapping("/{userId}/scrap-surveys")
 	public ResponseEntity<List<ScrapSurveyResponse>> getScrapSurveys(@PathVariable Long userId) {
 		List<ScrapSurveyResponse> scrapSurveyResponses = userMyService.getScrapSurveys(userId);
 		return ResponseEntity.ok(scrapSurveyResponses);
 	}
 
-	@PostMapping("/{userId}/scrap-survey")
+	@PostMapping("/{userId}/scrap-surveys")
 	public ResponseEntity<ScrapSurveyResponse> addScrapSurvey(
 		@PathVariable Long userId,
 		@RequestBody ScrapSurveyRequest scrapSurveyRequest
@@ -72,12 +75,39 @@ public class UserMyController {
 		return ResponseEntity.ok(scrapSurveyResponse);
 	}
 
-	@DeleteMapping("/{userId}/scrap-survey/{scrapSurveyId}")
+	@DeleteMapping("/{userId}/scrap-surveys/{scrapSurveyId}")
 	public ResponseEntity<Void> removeScrapSurvey(
 		@PathVariable Long userId,
 		@PathVariable Long scrapSurveyId
 	) {
 		userMyService.removeScrapSurvey(userId, scrapSurveyId);
+
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/{userId}/scrap-products")
+	public ResponseEntity<List<ScrapProductResponse>> getScrapProducts(@PathVariable Long userId) {
+		List<ScrapProductResponse> scrapProductResponses = userMyService.getScrapProducts(userId);
+		return ResponseEntity.ok(scrapProductResponses);
+	}
+
+	@PostMapping("/{userId}/scrap-products")
+	public ResponseEntity<ScrapProductResponse> addScrapProduct(
+		@PathVariable Long userId,
+		@RequestBody ScrapProductRequest scrapProductRequest
+	) {
+		ScrapProduct scrapProduct = scrapProductRequest.scrapProduct();
+		ScrapProductResponse scrapProductResponse = userMyService.addScrapProduct(userId, scrapProduct);
+
+		return ResponseEntity.ok(scrapProductResponse);
+	}
+
+	@DeleteMapping("/{userId}/scrap-products/{scrapProductId}")
+	public ResponseEntity<Void> removeScrapProduct(
+		@PathVariable Long userId,
+		@PathVariable Long scrapProductId
+	) {
+		userMyService.removeScrapProduct(userId, scrapProductId);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
@@ -1,0 +1,30 @@
+package com.juwoong.opiniontrade.user.api;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.user.application.UserMyService;
+import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+
+@RestController
+@RequestMapping("/users/my")
+public class UserMyController {
+	private final UserMyService userMyService;
+
+	public UserMyController(UserMyService userMyService) {
+		this.userMyService = userMyService;
+	}
+
+	@GetMapping("/{userId}/friends")
+	public ResponseEntity<List<FriendResponse>> getFriends(
+		@PathVariable Long userId
+	) {
+		List<FriendResponse> friendResponses = userMyService.getFriends(userId);
+		return ResponseEntity.ok(friendResponses);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserMyController.java
@@ -12,9 +12,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.juwoong.opiniontrade.user.api.request.FriendRequest;
+import com.juwoong.opiniontrade.user.api.request.ScrapSurveyRequest;
 import com.juwoong.opiniontrade.user.application.UserMyService;
 import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.application.response.ScrapSurveyResponse;
 import com.juwoong.opiniontrade.user.domain.Friend;
+import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
 
 @RestController
 @RequestMapping("/users/my")
@@ -47,7 +50,34 @@ public class UserMyController {
 		@PathVariable Long userId,
 		@PathVariable Long friendId
 	) {
-		userMyService.removeFriend(friendId);
+		userMyService.removeFriend(userId, friendId);
+
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/{userId}/scrap-survey")
+	public ResponseEntity<List<ScrapSurveyResponse>> getScrapSurveys(@PathVariable Long userId) {
+		List<ScrapSurveyResponse> scrapSurveyResponses = userMyService.getScrapSurveys(userId);
+		return ResponseEntity.ok(scrapSurveyResponses);
+	}
+
+	@PostMapping("/{userId}/scrap-survey")
+	public ResponseEntity<ScrapSurveyResponse> addScrapSurvey(
+		@PathVariable Long userId,
+		@RequestBody ScrapSurveyRequest scrapSurveyRequest
+	) {
+		ScrapSurvey scrapSurvey = scrapSurveyRequest.scrapSurvey();
+		ScrapSurveyResponse scrapSurveyResponse = userMyService.addScrapSurvey(userId, scrapSurvey);
+
+		return ResponseEntity.ok(scrapSurveyResponse);
+	}
+
+	@DeleteMapping("/{userId}/scrap-survey/{scrapSurveyId}")
+	public ResponseEntity<Void> removeScrapSurvey(
+		@PathVariable Long userId,
+		@PathVariable Long scrapSurveyId
+	) {
+		userMyService.removeScrapSurvey(userId, scrapSurveyId);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/UserSelectController.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/UserSelectController.java
@@ -1,0 +1,28 @@
+package com.juwoong.opiniontrade.user.api;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.user.application.UserSelectService;
+import com.juwoong.opiniontrade.user.application.response.UserResponse;
+
+@RestController
+@RequestMapping("/users")
+public class UserSelectController {
+	private final UserSelectService userSelectService;
+
+	public UserSelectController(UserSelectService userSelectService) {
+		this.userSelectService = userSelectService;
+	}
+
+	@GetMapping
+	public ResponseEntity<List<UserResponse>> getUsers() {
+		List<UserResponse> userResponses = userSelectService.getUsers();
+
+		return ResponseEntity.ok(userResponses);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/ActivityInfoRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/ActivityInfoRequest.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.ActivityInfo;
+
+public record ActivityInfoRequest(
+	ActivityInfo activityInfo
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/FriendRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/FriendRequest.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.Friend;
+
+public record FriendRequest(
+	Friend friend
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/LoginRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.Email;
+import com.juwoong.opiniontrade.user.domain.Password;
+
+public record LoginRequest(
+	Email email,
+	Password password
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/ProfileInfoRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/ProfileInfoRequest.java
@@ -3,7 +3,6 @@ package com.juwoong.opiniontrade.user.api.request;
 import com.juwoong.opiniontrade.user.domain.ProfileInfo;
 
 public record ProfileInfoRequest(
-	Long userId,
 	ProfileInfo profileInfo
 ) {
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/ProfileInfoRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/ProfileInfoRequest.java
@@ -1,0 +1,9 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.ProfileInfo;
+
+public record ProfileInfoRequest(
+	Long userId,
+	ProfileInfo profileInfo
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/ScrapProductRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/ScrapProductRequest.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.ScrapProduct;
+
+public record ScrapProductRequest(
+	ScrapProduct scrapProduct
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/ScrapSurveyRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/ScrapSurveyRequest.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
+
+public record ScrapSurveyRequest(
+	ScrapSurvey scrapSurvey
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/api/request/SignUpRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/api/request/SignUpRequest.java
@@ -1,0 +1,10 @@
+package com.juwoong.opiniontrade.user.api.request;
+
+import com.juwoong.opiniontrade.user.domain.Email;
+import com.juwoong.opiniontrade.user.domain.Password;
+
+public record SignUpRequest(
+	Email email,
+	Password password
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserAccountService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserAccountService.java
@@ -11,10 +11,10 @@ import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
 
 @Service
 @Transactional(readOnly = true)
-public class UserService {
+public class UserAccountService {
 	private final UserRepository userRepository;
 
-	public UserService(UserRepository userRepository) {
+	public UserAccountService(UserRepository userRepository) {
 		this.userRepository = userRepository;
 	}
 

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
@@ -3,7 +3,9 @@ package com.juwoong.opiniontrade.user.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.juwoong.opiniontrade.user.application.response.ActivityInfoResponse;
 import com.juwoong.opiniontrade.user.application.response.ProfileInfoResponse;
+import com.juwoong.opiniontrade.user.domain.ActivityInfo;
 import com.juwoong.opiniontrade.user.domain.ProfileInfo;
 import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
 
@@ -30,5 +32,13 @@ public class UserInfoService {
 
 		ProfileInfo profileInfo = new ProfileInfo();
 		return new ProfileInfoResponse(profileInfo);
+	}
+
+	@Transactional
+	public ActivityInfoResponse updateActivityInfo(Long userId, ActivityInfo activityInfo) {
+		// find(userId);
+		// user.updateProfileInfo(profileInfo);
+
+		return new ActivityInfoResponse(activityInfo);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
@@ -1,0 +1,26 @@
+package com.juwoong.opiniontrade.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.user.application.response.ProfileInfoResponse;
+import com.juwoong.opiniontrade.user.domain.ProfileInfo;
+import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserInfoService {
+	private final UserRepository userRepository;
+
+	public UserInfoService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@Transactional
+	public ProfileInfoResponse updateProfileInfo(Long userId, ProfileInfo profileInfo) {
+		// find(userId);
+		// user.updateProfileInfo(profileInfo);
+
+		return new ProfileInfoResponse(profileInfo);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
@@ -41,4 +41,12 @@ public class UserInfoService {
 
 		return new ActivityInfoResponse(activityInfo);
 	}
+
+	public ActivityInfoResponse getActivityInfo(Long userId) {
+		// find(userId);
+		// ProfileInfo profileInfo = user.getProfileInfo();
+
+		ActivityInfo activityInfo = new ActivityInfo();
+		return new ActivityInfoResponse(activityInfo);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserInfoService.java
@@ -23,4 +23,12 @@ public class UserInfoService {
 
 		return new ProfileInfoResponse(profileInfo);
 	}
+
+	public ProfileInfoResponse getProfileInfo(Long userId) {
+		// find(userId);
+		// ProfileInfo profileInfo = user.getProfileInfo();
+
+		ProfileInfo profileInfo = new ProfileInfo();
+		return new ProfileInfoResponse(profileInfo);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.application.response.ScrapProductResponse;
 import com.juwoong.opiniontrade.user.application.response.ScrapSurveyResponse;
 import com.juwoong.opiniontrade.user.domain.Friend;
+import com.juwoong.opiniontrade.user.domain.ScrapProduct;
 import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
 import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
 
@@ -67,5 +69,29 @@ public class UserMyService {
 	public void removeScrapSurvey(Long userId, Long scrapSurveyId) {
 		// find(userId);
 		// user.removeScrapSurvey(scrapSurveyId);
+	}
+
+	public List<ScrapProductResponse> getScrapProducts(Long userId) {
+		List<ScrapProduct> scrapProducts = List.of(
+			new ScrapProduct(1L, "title1", 100L),
+			new ScrapProduct(2L, "title2", 100L),
+			new ScrapProduct(3L, "title3", 100L)
+		);
+
+		List<ScrapProductResponse> scrapProductResponses = scrapProducts.stream()
+			.map(scrapProduct -> new ScrapProductResponse(scrapProduct))
+			.toList();
+
+		return scrapProductResponses;
+	}
+
+	@Transactional
+	public ScrapProductResponse addScrapProduct(Long userId, ScrapProduct scrapProduct) {
+		//
+		return new ScrapProductResponse(scrapProduct);
+	}
+
+	@Transactional
+	public void removeScrapProduct(Long userId, Long scrapProductId) {
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
@@ -1,0 +1,31 @@
+package com.juwoong.opiniontrade.user.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.domain.Friend;
+import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserMyService {
+	private final UserRepository userRepository;
+
+	public UserMyService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	public List<FriendResponse> getFriends(Long userId) {
+		List<Friend> friends = List.of(
+			new Friend(1L, "friend1"),
+			new Friend(2L, "friend2"),
+			new Friend(3L, "friend3")
+		);
+
+		List<FriendResponse> friendResponses = friends.stream().map(friend -> new FriendResponse(friend)).toList();
+		return friendResponses;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
@@ -28,4 +28,18 @@ public class UserMyService {
 		List<FriendResponse> friendResponses = friends.stream().map(friend -> new FriendResponse(friend)).toList();
 		return friendResponses;
 	}
+
+	@Transactional
+	public FriendResponse addFriend(Long userId, Friend friend) {
+		// find(userId);
+		// user.addFriend(friend);
+
+		return new FriendResponse(friend);
+	}
+
+	@Transactional
+	public void removeFriend(Long friendId) {
+		// find(userId);
+		// user.removeFriend(friendId);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserMyService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.user.application.response.FriendResponse;
+import com.juwoong.opiniontrade.user.application.response.ScrapSurveyResponse;
 import com.juwoong.opiniontrade.user.domain.Friend;
+import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
 import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
 
 @Service
@@ -19,11 +21,7 @@ public class UserMyService {
 	}
 
 	public List<FriendResponse> getFriends(Long userId) {
-		List<Friend> friends = List.of(
-			new Friend(1L, "friend1"),
-			new Friend(2L, "friend2"),
-			new Friend(3L, "friend3")
-		);
+		List<Friend> friends = List.of(new Friend(1L, "friend1"), new Friend(2L, "friend2"), new Friend(3L, "friend3"));
 
 		List<FriendResponse> friendResponses = friends.stream().map(friend -> new FriendResponse(friend)).toList();
 		return friendResponses;
@@ -38,8 +36,36 @@ public class UserMyService {
 	}
 
 	@Transactional
-	public void removeFriend(Long friendId) {
+	public void removeFriend(Long userId, Long friendId) {
 		// find(userId);
 		// user.removeFriend(friendId);
+	}
+
+	public List<ScrapSurveyResponse> getScrapSurveys(Long userId) {
+		List<ScrapSurvey> scrapSurveys = List.of(
+			new ScrapSurvey(1L, "title1", "description1"),
+			new ScrapSurvey(2L, "title2", "description2"),
+			new ScrapSurvey(3L, "title3", "description3")
+		);
+
+		List<ScrapSurveyResponse> scrapSurveyResponses = scrapSurveys.stream()
+			.map(scrapSurvey -> new ScrapSurveyResponse(scrapSurvey))
+			.toList();
+
+		return scrapSurveyResponses;
+	}
+
+	@Transactional
+	public ScrapSurveyResponse addScrapSurvey(Long userId, ScrapSurvey scrapSurvey) {
+		// find(userId);
+		// user.addScrapSurvey(scrapSurvey);
+
+		return new ScrapSurveyResponse(scrapSurvey);
+	}
+
+	@Transactional
+	public void removeScrapSurvey(Long userId, Long scrapSurveyId) {
+		// find(userId);
+		// user.removeScrapSurvey(scrapSurveyId);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserSelectService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserSelectService.java
@@ -1,0 +1,34 @@
+package com.juwoong.opiniontrade.user.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.user.application.response.UserResponse;
+import com.juwoong.opiniontrade.user.domain.Email;
+import com.juwoong.opiniontrade.user.domain.Password;
+import com.juwoong.opiniontrade.user.domain.User;
+import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserSelectService {
+	private UserRepository userRepository;
+
+	public UserSelectService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	public List<UserResponse> getUsers() {
+		List<User> users = List.of(
+			new User(new Email("email"), new Password("password")),
+			new User(new Email("email2"), new Password("password2")),
+			new User(new Email("email3"), new Password("password3"))
+		);
+
+		List<UserResponse> userResponses = users.stream().map(user -> new UserResponse(user)).toList();
+
+		return userResponses;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
@@ -3,6 +3,7 @@ package com.juwoong.opiniontrade.user.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.juwoong.opiniontrade.user.application.response.LoginResponse;
 import com.juwoong.opiniontrade.user.application.response.SignUpResponse;
 import com.juwoong.opiniontrade.user.domain.Email;
 import com.juwoong.opiniontrade.user.domain.Password;
@@ -19,11 +20,18 @@ public class UserService {
 
 	@Transactional
 	public SignUpResponse signUp(Email email, Password password) {
-		// 검증
 		// new User(email, password)
 		// save
 
 		Long tempUserId = 1L;
 		return new SignUpResponse(tempUserId);
+	}
+
+	public LoginResponse login(Email email, Password password) {
+		// findByEmailAndPassword(email)
+		// validatePassword(password)
+
+		Long tempUserId = 1L;
+		return new LoginResponse(tempUserId);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
@@ -1,0 +1,16 @@
+package com.juwoong.opiniontrade.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/UserService.java
@@ -3,6 +3,9 @@ package com.juwoong.opiniontrade.user.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.juwoong.opiniontrade.user.application.response.SignUpResponse;
+import com.juwoong.opiniontrade.user.domain.Email;
+import com.juwoong.opiniontrade.user.domain.Password;
 import com.juwoong.opiniontrade.user.domain.repository.UserRepository;
 
 @Service
@@ -12,5 +15,15 @@ public class UserService {
 
 	public UserService(UserRepository userRepository) {
 		this.userRepository = userRepository;
+	}
+
+	@Transactional
+	public SignUpResponse signUp(Email email, Password password) {
+		// 검증
+		// new User(email, password)
+		// save
+
+		Long tempUserId = 1L;
+		return new SignUpResponse(tempUserId);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/ActivityInfoResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/ActivityInfoResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.ActivityInfo;
+
+public record ActivityInfoResponse(
+	ActivityInfo activityInfo
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/FriendResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/FriendResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.Friend;
+
+public record FriendResponse(
+	Friend friend
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/LoginResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+public record LoginResponse(
+	Long userId
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/ProfileInfoResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/ProfileInfoResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.ProfileInfo;
+
+public record ProfileInfoResponse(
+	ProfileInfo profileInfo
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/ScrapProductResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/ScrapProductResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.ScrapProduct;
+
+public record ScrapProductResponse(
+	ScrapProduct scrapProduct
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/ScrapSurveyResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/ScrapSurveyResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.ScrapSurvey;
+
+public record ScrapSurveyResponse(
+	ScrapSurvey scrapSurvey
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/SignUpResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/SignUpResponse.java
@@ -1,0 +1,6 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+public record SignUpResponse(
+	Long userId
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/application/response/UserResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/application/response/UserResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.application.response;
+
+import com.juwoong.opiniontrade.user.domain.User;
+
+public record UserResponse(
+	User user
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/ActivityInfo.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/ActivityInfo.java
@@ -4,8 +4,10 @@ import org.hibernate.annotations.ColumnDefault;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ActivityInfo {
 	@Column(name = "request_count")
 	@ColumnDefault(value = "0")

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/Email.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/Email.java
@@ -2,8 +2,10 @@ package com.juwoong.opiniontrade.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class Email {
 	@Column(name = "email", nullable = false)
 	private String email;

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/Friend.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/Friend.java
@@ -5,10 +5,11 @@ import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
 @Embeddable
+@Getter
 public class Friend {
 
 	@Column(name = "firend_id", nullable = false)
-	private String friendId;
+	private Long friendId;
 
 	@Column(name = "friend_name", nullable = false)
 	private String friendName;
@@ -16,7 +17,7 @@ public class Friend {
 	protected Friend() {
 	}
 
-	public Friend(String friendId, String friendName) {
+	public Friend(Long friendId, String friendName) {
 		this.friendId = friendId;
 		this.friendName = friendName;
 	}

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/Password.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/Password.java
@@ -2,8 +2,10 @@ package com.juwoong.opiniontrade.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class Password {
 	@Column(name = "password", nullable = false)
 	private String password;

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/ProfileInfo.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/ProfileInfo.java
@@ -7,8 +7,10 @@ import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ProfileInfo {
 	@Column(name = "nick_name")
 	private String nickName;
@@ -17,7 +19,7 @@ public class ProfileInfo {
 	private String introduction;
 
 	@Column(name = "age")
-	private String age;
+	private Long age;
 
 	@Column(name = "job")
 	private String job;

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapProduct.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapProduct.java
@@ -2,15 +2,26 @@ package com.juwoong.opiniontrade.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ScrapProduct {
 	@Column(name = "scrap_product_id", nullable = false)
-	private String scrapProductId;
+	private Long scrapProductId;
 
 	@Column(name = "scrip_product_title", nullable = false)
 	private String scrapSurveyTitle;
 
 	@Column(name = "scrip_product_price", nullable = false)
 	private Long scrapSurveyPrice;
+
+	protected ScrapProduct() {
+	}
+
+	public ScrapProduct(Long scrapProductId, String scrapSurveyTitle, Long scrapSurveyPrice) {
+		this.scrapProductId = scrapProductId;
+		this.scrapSurveyTitle = scrapSurveyTitle;
+		this.scrapSurveyPrice = scrapSurveyPrice;
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapProduct.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapProduct.java
@@ -1,7 +1,16 @@
 package com.juwoong.opiniontrade.user.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class ScrapProduct {
+	@Column(name = "scrap_product_id", nullable = false)
+	private String scrapProductId;
+
+	@Column(name = "scrip_product_title", nullable = false)
+	private String scrapSurveyTitle;
+
+	@Column(name = "scrip_product_price", nullable = false)
+	private Long scrapSurveyPrice;
 }

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapSurvey.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/ScrapSurvey.java
@@ -2,11 +2,13 @@ package com.juwoong.opiniontrade.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ScrapSurvey {
 	@Column(name = "scrap_survey_id", nullable = false)
-	private String scrapSurveyId;
+	private Long scrapSurveyId;
 
 	@Column(name = "scrip_survey_title", nullable = false)
 	private String scrapSurveyTitle;
@@ -17,7 +19,7 @@ public class ScrapSurvey {
 	protected ScrapSurvey() {
 	}
 
-	public ScrapSurvey(String scrapSurveyId, String scrapSurveyTitle, String scripSurveyDescription) {
+	public ScrapSurvey(Long scrapSurveyId, String scrapSurveyTitle, String scripSurveyDescription) {
 		this.scrapSurveyId = scrapSurveyId;
 		this.scrapSurveyTitle = scrapSurveyTitle;
 		this.scripSurveyDescription = scripSurveyDescription;

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.user.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.juwoong.opiniontrade.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
-  API 명세를 유저 도메인 API를 작성했습니다/

## 👨‍👩‍👦‍👦 주요 작업 설명
- 유저 도메인에서 제공해야하는 RestController 를 작성했습니다. 
- 서비스 계층은 더미데이터를 작성해서 API 테스트가 가능하도록 했습니다.
- 설문 도메인 작업 완료 시 Swagger를 통해 API문서를 진행할 것입니다. 

## 👨‍👩‍👧‍👧 기타 의견 
- 이전 프로젝트에서 API 를 노션으로 관리하다보디 변경사항을 최신화 하지 못한 문제가 많았습니다.
   따라서 프론트와 협업한다는 과정에서 필요한 API 문서를 먼저 제공하는 방식으로 작업 계획을 세웠습니다.  
