### PR TITLE
6 설문지 도메인 api 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
@@ -1,0 +1,35 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.survey.api.request.SurveyRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyService;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
+import com.juwoong.opiniontrade.survey.domain.Creator;
+
+@RestController
+@RequestMapping(value = "/surveys")
+public class SurveyController {
+	private final SurveyService surveyService;
+
+	public SurveyController(SurveyService surveyService) {
+		this.surveyService = surveyService;
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public SurveyResponse createSurvey(@RequestBody SurveyRequest surveyRequest) {
+		Creator creator = surveyRequest.creator();
+		String title = surveyRequest.title();
+		String description = surveyRequest.description();
+
+		SurveyResponse surveyResponse = surveyService.createSurvey(creator, title, description);
+
+		return surveyResponse;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.juwoong.opiniontrade.survey.api.request.QuestionRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyQuestionService;
 import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
+import com.juwoong.opiniontrade.survey.application.response.QuestionsResponse;
 import com.juwoong.opiniontrade.survey.domain.Option;
 
 @RestController
@@ -49,6 +51,15 @@ public class SurveyQuestionController {
 
 		return questionResponse;
 	}
+
+	@GetMapping("/{surveyId}/questions")
+	@ResponseStatus(HttpStatus.OK)
+	public QuestionsResponse getQuestions(@PathVariable Long surveyId){
+		QuestionsResponse questionsResponse = surveyQuestionService.getQuestions(surveyId);
+
+		return  questionsResponse;
+	}
+
 
 	@DeleteMapping("/{surveyId}/questions/{questionOrder}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -3,6 +3,7 @@ package com.juwoong.opiniontrade.survey.api;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,5 +46,14 @@ public class SurveyQuestionController {
 		);
 
 		return questionResponse;
+	}
+
+	@DeleteMapping("/{surveyId}/questions/{questionOrder}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteSurveyQuestion(
+		@PathVariable Long surveyId,
+		@PathVariable Integer questionOrder
+	) {
+		surveyQuestionService.removeSurvey(surveyId, questionOrder);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -1,0 +1,49 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.survey.api.request.QuestionRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyQuestionService;
+import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
+import com.juwoong.opiniontrade.survey.domain.Option;
+
+@RestController
+@RequestMapping(value = "/surveys")
+public class SurveyQuestionController {
+	private final SurveyQuestionService surveyQuestionService;
+
+	public SurveyQuestionController(SurveyQuestionService surveyQuestionService) {
+		this.surveyQuestionService = surveyQuestionService;
+	}
+
+	@PostMapping("/{surveyId}/questions")
+	@ResponseStatus(HttpStatus.CREATED)
+	public QuestionResponse createSurveyQuestion(
+		@PathVariable Long surveyId,
+		@RequestBody QuestionRequest questionRequest
+	) {
+		Integer questionOrder = questionRequest.questionOrder();
+
+		String title = questionRequest.title();
+		String description = questionRequest.description();
+		List<Option> options = questionRequest.options();
+
+		QuestionResponse questionResponse = surveyQuestionService.createQuestion(
+			surveyId,
+			questionOrder,
+			title,
+			description,
+			options
+		);
+
+		return questionResponse;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -6,8 +6,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,5 +57,15 @@ public class SurveyQuestionController {
 		@PathVariable Integer questionOrder
 	) {
 		surveyQuestionService.removeSurvey(surveyId, questionOrder);
+	}
+
+	@PutMapping("/{surveyId}/questions/change-order")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void changeQuestionOrder(
+		@PathVariable Long surveyId,
+		@RequestParam Integer oneOrder,
+		@RequestParam Integer anotherOrder
+	) {
+		surveyQuestionService.changeOrder(surveyId, oneOrder, anotherOrder);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -1,0 +1,46 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.survey.api.request.SurveyResultRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyResultService;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+
+@RestController(value = "/surveys")
+public class SurveyResultController {
+
+	private final SurveyResultService surveyResultService;
+
+	public SurveyResultController(SurveyResultService surveyResultService) {
+		this.surveyResultService = surveyResultService;
+	}
+
+	@PostMapping("/{surveyId}/survey-results")
+	@ResponseStatus(HttpStatus.CREATED)
+	public SurveyResultResponse receiveSurveyResult(
+		@PathVariable Long surveyId,
+		@RequestBody SurveyResultRequest surveyResultRequest
+	) {
+		Respondent respondent = surveyResultRequest.respondent();
+		List<Answer> answers = surveyResultRequest.answers();
+
+		SurveyResultResponse surveyResultResponse = surveyResultService.receiveSurveyResult(
+			surveyId,
+			respondent,
+			answers
+		);
+
+		return surveyResultResponse;
+	}
+
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -49,11 +49,22 @@ public class SurveyResultController {
 
 	@GetMapping("/{surveyId}/survey-results")
 	@ResponseStatus(HttpStatus.OK)
-	public SurveyResultsResponse getQuestionResults(
+	public SurveyResultsResponse getSurveyResults(
 		@PathVariable Long surveyId
 	) {
 		SurveyResultsResponse surveyResultsResponse = surveyResultService.getSurveyResults(surveyId);
 
 		return surveyResultsResponse;
+	}
+
+	@GetMapping("/{surveyId}/survey-results/{respondentId}")
+	@ResponseStatus(HttpStatus.OK)
+	public SurveyResultResponse getSurveyResult(
+		@PathVariable Long surveyId,
+		@PathVariable Long respondentId
+	) {
+		SurveyResultResponse surveyResultResponse = surveyResultService.getSurveyResult(surveyId, respondentId);
+
+		return surveyResultResponse;
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,5 +67,14 @@ public class SurveyResultController {
 		SurveyResultResponse surveyResultResponse = surveyResultService.getSurveyResult(surveyId, respondentId);
 
 		return surveyResultResponse;
+	}
+
+	@DeleteMapping("/{surveyId}/survey-results/{respondentId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteSurveyQuestion(
+		@PathVariable Long surveyId,
+		@PathVariable Long respondentId
+	) {
+		surveyResultService.removeSurveyResult(surveyId, respondentId);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -1,8 +1,10 @@
 package com.juwoong.opiniontrade.survey.api;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.juwoong.opiniontrade.survey.api.request.SurveyResultRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyResultService;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultsResponse;
 import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Question;
 import com.juwoong.opiniontrade.survey.domain.Respondent;
 import com.juwoong.opiniontrade.survey.domain.SurveyResult;
 
@@ -43,4 +47,13 @@ public class SurveyResultController {
 		return surveyResultResponse;
 	}
 
+	@GetMapping("/{surveyId}/survey-results")
+	@ResponseStatus(HttpStatus.OK)
+	public SurveyResultsResponse getQuestionResults(
+		@PathVariable Long surveyId
+	) {
+		SurveyResultsResponse surveyResultsResponse = surveyResultService.getSurveyResults(surveyId);
+
+		return surveyResultsResponse;
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
@@ -1,0 +1,13 @@
+package com.juwoong.opiniontrade.survey.api.request;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.Option;
+
+public record QuestionRequest(
+	Integer questionOrder,
+	String title,
+	String description,
+	List<Option> options
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyRequest.java
@@ -1,0 +1,10 @@
+package com.juwoong.opiniontrade.survey.api.request;
+
+import com.juwoong.opiniontrade.survey.domain.Creator;
+
+public record SurveyRequest(
+	Creator creator,
+	String title,
+	String description
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyResultRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyResultRequest.java
@@ -1,0 +1,12 @@
+package com.juwoong.opiniontrade.survey.api.request;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+
+public record SurveyResultRequest(
+	Respondent respondent,
+	List<Answer> answers
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -1,0 +1,35 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
+import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyQuestionService {
+	private final SurveyRepository surveyRepository;
+
+	public SurveyQuestionService(SurveyRepository surveyRepository) {
+		this.surveyRepository = surveyRepository;
+	}
+
+	public QuestionResponse createQuestion(
+		Long surveyId,
+		Integer questionOrder,
+		String title,
+		String description,
+		List<Option> options
+	) {
+		Question question = new Question(title, description, options);
+		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		// survey.createQuestion(questionOrder, question);
+
+		return new QuestionResponse(question);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
 import com.juwoong.opiniontrade.survey.domain.Option;
 import com.juwoong.opiniontrade.survey.domain.Question;
+import com.juwoong.opiniontrade.survey.domain.Survey;
 import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
 
 @Service
@@ -19,6 +20,7 @@ public class SurveyQuestionService {
 		this.surveyRepository = surveyRepository;
 	}
 
+	@Transactional
 	public QuestionResponse createQuestion(
 		Long surveyId,
 		Integer questionOrder,
@@ -31,5 +33,11 @@ public class SurveyQuestionService {
 		// survey.createQuestion(questionOrder, question);
 
 		return new QuestionResponse(question);
+	}
+
+	@Transactional
+	public void removeSurvey(Long surveyId, Integer questionOrder) {
+		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		// survey.removeQuestion(questionOrder);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -40,4 +40,10 @@ public class SurveyQuestionService {
 		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
 		// survey.removeQuestion(questionOrder);
 	}
+
+	@Transactional
+	public void changeOrder(Long surveyId, Integer oneOrder, Integer anotherOrder) {
+		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		// survey.changeQuestionOrder(oneOrder, anotherOrder);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -51,7 +51,7 @@ public class SurveyQuestionService {
 
 	public QuestionsResponse getQuestions(Long surveyId) {
 		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-		Map<Integer, Question> questions = survey.getQuestionWithOrder();
+		Map<Integer, Question> questions = survey.findQuestionWithOrder();
 
 		return new QuestionsResponse(questions);
 	}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -1,11 +1,13 @@
 package com.juwoong.opiniontrade.survey.application;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
+import com.juwoong.opiniontrade.survey.application.response.QuestionsResponse;
 import com.juwoong.opiniontrade.survey.domain.Option;
 import com.juwoong.opiniontrade.survey.domain.Question;
 import com.juwoong.opiniontrade.survey.domain.Survey;
@@ -45,5 +47,12 @@ public class SurveyQuestionService {
 	public void changeOrder(Long surveyId, Integer oneOrder, Integer anotherOrder) {
 		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
 		// survey.changeQuestionOrder(oneOrder, anotherOrder);
+	}
+
+	public QuestionsResponse getQuestions(Long surveyId) {
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		Map<Integer, Question> questions = survey.getQuestionWithOrder();
+
+		return new QuestionsResponse(questions);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -1,0 +1,32 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyResultService {
+	private final SurveyRepository surveyRepository;
+
+	public SurveyResultService(SurveyRepository surveyRepository) {
+		this.surveyRepository = surveyRepository;
+	}
+
+	public SurveyResultResponse receiveSurveyResult(Long surveyId, Respondent respondent, List<Answer> answers) {
+		SurveyResult surveyResult = new SurveyResult(respondent, answers);
+
+		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		// survey.receiveSurveyResult(surveyResult);
+
+		return new SurveyResultResponse(surveyResult);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultsResponse;
 import com.juwoong.opiniontrade.survey.domain.Answer;
 import com.juwoong.opiniontrade.survey.domain.Respondent;
 import com.juwoong.opiniontrade.survey.domain.Survey;
@@ -21,12 +22,20 @@ public class SurveyResultService {
 		this.surveyRepository = surveyRepository;
 	}
 
+	@Transactional
 	public SurveyResultResponse receiveSurveyResult(Long surveyId, Respondent respondent, List<Answer> answers) {
 		SurveyResult surveyResult = new SurveyResult(respondent, answers);
 
-		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-		// survey.receiveSurveyResult(surveyResult);
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		survey.receiveSurveyResult(surveyResult);
 
 		return new SurveyResultResponse(surveyResult);
+	}
+
+	public SurveyResultsResponse getSurveyResults(Long surveyId) {
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		List<SurveyResult> surveyResults = survey.findSurveyResult();
+
+		return new SurveyResultsResponse(surveyResults);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -49,4 +49,8 @@ public class SurveyResultService {
 
 		return new SurveyResultResponse(surveyResult);
 	}
+
+	@Transactional
+	public void removeSurveyResult(Long surveyId, Long respondentId) {
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -38,4 +38,15 @@ public class SurveyResultService {
 
 		return new SurveyResultsResponse(surveyResults);
 	}
+
+	public SurveyResultResponse getSurveyResult(Long surveyId, Long respondentId) {
+		// 쿼리 조회
+
+		Respondent tempRespondent = new Respondent(1L, "name");
+		List<Answer> tempAnswers =List.of(new Answer(1L, "contnet"));
+
+		SurveyResult surveyResult = new SurveyResult(tempRespondent, tempAnswers);
+
+		return new SurveyResultResponse(surveyResult);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
@@ -1,0 +1,26 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
+import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyService {
+	private final SurveyRepository surveyRepository;
+
+	public SurveyService(SurveyRepository surveyRepository) {
+		this.surveyRepository = surveyRepository;
+	}
+
+	@Transactional
+	public SurveyResponse createSurvey(Creator creator, String title, String description) {
+		Survey survey = new Survey(creator, title, description);
+
+		return new SurveyResponse(survey);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/QuestionResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/QuestionResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import com.juwoong.opiniontrade.survey.domain.Question;
+
+public record QuestionResponse(
+	Question question
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/QuestionsResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/QuestionsResponse.java
@@ -1,0 +1,10 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import java.util.Map;
+
+import com.juwoong.opiniontrade.survey.domain.Question;
+
+public record QuestionsResponse(
+	Map<Integer, Question> questions
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import com.juwoong.opiniontrade.survey.domain.Survey;
+
+public record SurveyResponse(
+	Survey survey
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
@@ -1,0 +1,8 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+
+public record SurveyResultResponse(
+	SurveyResult surveyResult
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultsResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultsResponse.java
@@ -1,0 +1,10 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+
+public record SurveyResultsResponse(
+	List<SurveyResult> surveyResults
+) {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import lombok.Getter;
 
 @Entity
 public class Question {
@@ -18,12 +19,15 @@ public class Question {
 	@Column(name = "question_id")
 	private Long id;
 
+	@Getter
 	@Column(name = "question_title")
 	private String title;
 
+	@Getter
 	@Column(name = "question_description")
 	private String description;
 
+	@Getter
 	@ElementCollection
 	@CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
 	private List<Option> options;

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -21,6 +21,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import lombok.Getter;
 
 @Entity
 public class Survey extends TimeBaseEntity {
@@ -33,19 +34,23 @@ public class Survey extends TimeBaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Getter
 	@Column(name = "survey_title")
 	private String title;
 
+	@Getter
 	@Column(name = "survey_description")
 	private String description;
 
 	@Column(name = "category_id")
 	private Long categoryId;
 
+	@Getter
 	@Column(name = "survey_status")
 	@Enumerated(value = EnumType.STRING)
 	private SurveyStatus surveyStatus;
 
+	@Getter
 	@Embedded
 	private Creator creator;
 
@@ -60,6 +65,7 @@ public class Survey extends TimeBaseEntity {
 	@Embedded
 	private RequestInfo requestInfo;
 
+	@Getter
 	@Column(name = "view_count")
 	private Long viewCount;
 
@@ -75,6 +81,7 @@ public class Survey extends TimeBaseEntity {
 		this.title = title;
 		this.description = description;
 		this.surveyStatus = SurveyStatus.CREATE;
+		this.viewCount = 0L;
 	}
 
 	public Long getSurveyId() {

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -119,6 +119,10 @@ public class Survey extends TimeBaseEntity {
 	public void changeQuestionOrder(Integer oneQuestionOrder, Integer anotherQuestionOrder) {
 	}
 
+	public Map<Integer, Question> getQuestionWithOrder() {
+		return questions;
+	}
+
 	public void receiveSurveyResult(SurveyResult surveyResult) {
 		surveyResults.add(surveyResult);
 	}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -119,7 +119,7 @@ public class Survey extends TimeBaseEntity {
 	public void changeQuestionOrder(Integer oneQuestionOrder, Integer anotherQuestionOrder) {
 	}
 
-	public Map<Integer, Question> getQuestionWithOrder() {
+	public Map<Integer, Question> findQuestionWithOrder() {
 		return questions;
 	}
 
@@ -128,6 +128,10 @@ public class Survey extends TimeBaseEntity {
 	}
 
 	public void updateSurveyResult(Respondent respondent, SurveyResult surveyResult) {
+	}
+
+	public List<SurveyResult> findSurveyResult() {
+		return surveyResults;
 	}
 
 	public void updateRequestInfo(RequestInfo requestInfo) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import lombok.Getter;
 
 @Entity
 public class SurveyResult extends TimeBaseEntity {
@@ -21,9 +22,11 @@ public class SurveyResult extends TimeBaseEntity {
 	@Column(name = "survey_result_id")
 	private Long id;
 
+	@Getter
 	@Embedded
 	private Respondent respondent;
 
+	@Getter
 	@ElementCollection
 	@CollectionTable(name = "survey_result_answers", joinColumns = @JoinColumn(name = "survey_result_id"))
 	private List<Answer> answers;


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문지 도메인에 대한 api를 작성했습니다.
- 설문지 도메인 api가 많아 PR이 커지는 것을 방지해 해당 PR은 설문지, 질문 문항, 답변자 답변 자원에 대한 CRUD만 작성했습니다.
- 이후 기본 사이클 단계 위주로 추가 api 명세 생성 작업을 할 것 입니다.

## 👨‍👩‍👦‍👦 주요 작업 설명
- 설문지, 질문 문항, 답변자 답변에 대한 CRUD API 작성
- swagger 의존성 추가

## 👨‍👩‍👧‍👧 기타 의견 
- swagger를 적용하면서 api 작성 및 테스트에서 자유로워젔습니다.
  기존 post man으로 명세를 작성하고 테스트 해보면서 드는 시간을 제거 했습니다.
   swagger 는 별다른 설정 없이도 명세확인과 테스트는 가능하니 처음 시작할때 부터 적용하면 괜찮을 것 같습니다. 

- 크기가 큰 루트엔티티에서 필요한 멤머변수값만 응답값으로 줄 수 있음을 알았습니다.
  설문지와 관련된 모든 항목을 Survey 루트 엔티티에만 두다 보니 조회시 모든 값을 다 불러올 수 있다는 문제가 있었습니다.
  설문지, 질문 문항, 답변자를 각각의 자원으로 사용해서 api를 적용하고 싶었습니다.
  클래스에 조회값으로 주고 싶은 필드만 getter 메서드를 추가한다면 원하는 값만 응답값으로 전달 할 수 있습니다.
