### PR TITLE
설문 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // bean validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 

--- a/src/main/java/com/juwoong/opiniontrade/OpinionTradeApplication.java
+++ b/src/main/java/com/juwoong/opiniontrade/OpinionTradeApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+//@EnableJpaAuditing
 @SpringBootApplication
 public class OpinionTradeApplication {
 

--- a/src/main/java/com/juwoong/opiniontrade/config/JpaConfiguration.java
+++ b/src/main/java/com/juwoong/opiniontrade/config/JpaConfiguration.java
@@ -1,0 +1,9 @@
+package com.juwoong.opiniontrade.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfiguration {
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
@@ -1,16 +1,25 @@
 package com.juwoong.opiniontrade.survey.api;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.juwoong.opiniontrade.survey.api.request.RequestInfoRequest;
 import com.juwoong.opiniontrade.survey.api.request.SurveyRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyService;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
 import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.RequestInfo;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping(value = "/surveys")
@@ -23,7 +32,7 @@ public class SurveyController {
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
-	public SurveyResponse createSurvey(@RequestBody SurveyRequest surveyRequest) {
+	public SurveyResponse createSurvey(@Valid @RequestBody SurveyRequest surveyRequest) {
 		Creator creator = surveyRequest.creator();
 		String title = surveyRequest.title();
 		String description = surveyRequest.description();
@@ -32,4 +41,18 @@ public class SurveyController {
 
 		return surveyResponse;
 	}
+
+	@PutMapping("/{surveyId}/request")
+	@ResponseStatus(HttpStatus.OK)
+	public void requestSurvey(
+		@PathVariable Long surveyId,
+		@RequestBody RequestInfoRequest requestInfoRequest
+	) {
+
+		RequestInfo requestInfo = requestInfoRequest.requestInfo();
+		List<Respondent> respondents = requestInfoRequest.assignedRespondent();
+		//surveyService.requestSurvey(surveyId, requestInfo, respondents);
+
+	}
+
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -1,7 +1,6 @@
 package com.juwoong.opiniontrade.survey.api;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,9 +16,7 @@ import com.juwoong.opiniontrade.survey.application.SurveyResultService;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResultsResponse;
 import com.juwoong.opiniontrade.survey.domain.Answer;
-import com.juwoong.opiniontrade.survey.domain.Question;
 import com.juwoong.opiniontrade.survey.domain.Respondent;
-import com.juwoong.opiniontrade.survey.domain.SurveyResult;
 
 @RestController(value = "/surveys")
 public class SurveyResultController {
@@ -71,7 +68,7 @@ public class SurveyResultController {
 
 	@DeleteMapping("/{surveyId}/survey-results/{respondentId}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void deleteSurveyQuestion(
+	public void deleteSurveyResult(
 		@PathVariable Long surveyId,
 		@PathVariable Long respondentId
 	) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/SurveyRequest.java
@@ -2,9 +2,13 @@ package com.juwoong.opiniontrade.survey.api.request;
 
 import com.juwoong.opiniontrade.survey.domain.Creator;
 
+import jakarta.validation.constraints.Size;
+
 public record SurveyRequest(
 	Creator creator,
+	@Size(min =0, max = 50)
 	String title,
+	@Size(min =0, max = 200)
 	String description
 ) {
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
@@ -1,10 +1,14 @@
 package com.juwoong.opiniontrade.survey.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
 import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.RequestInfo;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
 import com.juwoong.opiniontrade.survey.domain.Survey;
 import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
 
@@ -20,7 +24,8 @@ public class SurveyService {
 	@Transactional
 	public SurveyResponse createSurvey(Creator creator, String title, String description) {
 		Survey survey = new Survey(creator, title, description);
+		Survey createdSurvey = surveyRepository.save(survey);
 
-		return new SurveyResponse(survey);
+		return new SurveyResponse(createdSurvey);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Creator.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Creator.java
@@ -2,20 +2,22 @@ package com.juwoong.opiniontrade.survey.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class Creator {
 	@Column(name = "creator_id", nullable = false)
 	Long creatorId;
 
 	@Column(name = "creator_nickname")
-	String nickName;
+	String nickname;
 
 	protected Creator() {
 	}
 
-	public Creator(Long creatorId, String nickName) {
+	public Creator(Long creatorId, String nickname) {
 		this.creatorId = creatorId;
-		this.nickName = nickName;
+		this.nickname = nickname;
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyControllerTest.java
@@ -1,0 +1,58 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.juwoong.opiniontrade.survey.api.request.SurveyRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyService;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
+import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+
+@WebMvcTest(SurveyController.class)
+class SurveyControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SurveyService surveyService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	void createSurvey() throws Exception {
+		// given
+		Creator creator = new Creator(1L, "juwoongKim");
+		String title = "surveyTitle";
+		String description = "surveyDescription";
+
+		String request = objectMapper.writeValueAsString(new SurveyRequest(creator, title, description));
+		SurveyResponse surveyResponse = new SurveyResponse(new Survey(creator, title, description));
+
+		when(surveyService.createSurvey(any(Creator.class), anyString(), anyString())).thenReturn(surveyResponse);
+
+		// when then
+		mockMvc.perform(post("/surveys")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("survey.creator.creatorId").value(1))
+			.andExpect(jsonPath("survey.creator.nickname").value("juwoongKim"))
+			.andExpect(jsonPath("survey.title").value("surveyTitle"))
+			.andExpect(jsonPath("survey.description").value("surveyDescription"));
+
+		SurveyResponse survey = verify(surveyService, times(1)).createSurvey(any(Creator.class), anyString(),
+			anyString());
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyServiceTest.java
@@ -1,0 +1,45 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
+import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyServiceTest {
+	@InjectMocks
+	private SurveyService surveyService;
+
+	@Mock
+	private SurveyRepository surveyRepository;
+
+	@Test
+	@DisplayName("유저가 설문지 생성에 성공한다.")
+	void createSurvey() {
+		// given
+		Creator creator = new Creator(1L, "juwoongKim");
+		String title = "surveyTitle";
+		String description = "surveyDescription";
+		Survey survey = new Survey(creator, title, description);
+
+		when(surveyRepository.save(any(Survey.class))).thenReturn(survey);
+
+		// when
+		SurveyResponse surveyResponse = surveyService.createSurvey(creator, title, description);
+
+		// then
+		verify(surveyRepository, times(1)).save(any(Survey.class));
+		assertThat(surveyResponse.survey()).extracting("creator.nickname", "title", "description")
+			.containsExactly(creator.getNickname(), title, description);
+	}
+}


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문 도메인의 설문 생성 기능을 구현했습니다.
- 설문지와 질문 api를 분리했기 때문에 생성은 아래의 구글폼과 같이 설문지 자체에 대한 생성을 의미합니다.
<img width="1034" alt="스크린샷 2024-02-17 오후 11 22 16" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/2b6608ec-4456-4b31-b203-b30afb566d7c">

## 👨‍👩‍👦‍👦 주요 작업 설명
- 모키토를 사용해 계층별 슬라이스 테스트를 진행했습니다.
- bean validation 을 적용했고 슬라이스 테스트를 통해 동작 과정을 확인했습니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 현재는 빠른 기능 구현을 위해 dto에 bean validation을 적용하고 컨트롤러에서 확인합니다.
  하지만 생성자 또는 특정 메서드를 통해 도메인 객체가 생성될 때 검증해서 도메인 자체가 검증 될 수 있도록 변경할 예정입니다.


