### PR TITLE
14 질문 생성 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
@@ -3,11 +3,13 @@ package com.juwoong.opiniontrade.survey.api.request;
 import java.util.List;
 
 import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
 
 public record QuestionRequest(
 	Integer questionOrder,
 	String title,
 	String description,
+	Question.Type type,
 	List<Option> options
 ) {
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
 import com.juwoong.opiniontrade.survey.application.response.QuestionsResponse;
 import com.juwoong.opiniontrade.survey.domain.Option;
 import com.juwoong.opiniontrade.survey.domain.Question;
@@ -23,18 +22,18 @@ public class SurveyQuestionService {
 	}
 
 	@Transactional
-	public QuestionResponse createQuestion(
+	public void createQuestion(
 		Long surveyId,
 		Integer questionOrder,
 		String title,
 		String description,
+		Question.Type type,
 		List<Option> options
 	) {
-		Question question = new Question(title, description, options);
-		// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-		// survey.createQuestion(questionOrder, question);
+		Question question = type.create(title, description, options);
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
 
-		return new QuestionResponse(question);
+		survey.createQuestion(questionOrder, question);
 	}
 
 	@Transactional

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Option.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Option.java
@@ -2,7 +2,9 @@ package com.juwoong.opiniontrade.survey.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class Option {
 	@Column(name = "question_option")

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
@@ -32,7 +32,7 @@ public abstract class Question {
 		CHECKBOX((title, descriptions, options) -> new QuestionCheckbox(title, descriptions, options)),
 		DROPDOWN((title, descriptions, options) -> new QuestionDropdown(title, descriptions, options));
 
-		public final TriFunction<String, String, List<Option>, Question> creator;
+		private final TriFunction<String, String, List<Option>, Question> creator;
 
 		Type(TriFunction<String, String, List<Option>, Question> creator) {
 			this.creator = creator;

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
@@ -2,18 +2,47 @@ package com.juwoong.opiniontrade.survey.domain;
 
 import java.util.List;
 
-import jakarta.persistence.CollectionTable;
+import org.apache.commons.lang3.function.TriFunction;
+
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
+import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
-public class Question {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@AllArgsConstructor
+@DiscriminatorColumn(name = "dtype")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Question {
+	public enum Type {
+		SHORT_ANSWER((title, descriptions, options) -> new QuestionShortAnswer(title, descriptions)),
+		PARAGRAPH((title, descriptions, options) -> new QuestionParagraph(title, descriptions)),
+		MULTIPLE_CHOICE((title, descriptions, options) -> new QuestionMultipleChoice(title, descriptions, options)),
+		CHECKBOX((title, descriptions, options) -> new QuestionCheckbox(title, descriptions, options)),
+		DROPDOWN((title, descriptions, options) -> new QuestionDropdown(title, descriptions, options));
+
+		public final TriFunction<String, String, List<Option>, Question> creator;
+
+		Type(TriFunction<String, String, List<Option>, Question> creator) {
+			this.creator = creator;
+		}
+
+		public Question create(String title, String description, List<Option> options) {
+			return creator.apply(title, description, options);
+		}
+	}
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "question_id")
@@ -28,16 +57,11 @@ public class Question {
 	private String description;
 
 	@Getter
-	@ElementCollection
-	@CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
-	private List<Option> options;
+	@Enumerated(EnumType.STRING)
+	protected Type type;
 
-	protected Question() {
-	}
-
-	public Question(String title, String description, List<Option> options) {
+	protected Question(String title, String description) {
 		this.title = title;
 		this.description = description;
-		this.options = options;
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionCheckbox.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionCheckbox.java
@@ -1,0 +1,30 @@
+package com.juwoong.opiniontrade.survey.domain;
+
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue(value = "checkbox")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionCheckbox extends Question {
+	@Getter
+	@ElementCollection
+	@CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+	private List<Option> options;
+
+	public QuestionCheckbox(String title, String description, List<Option> options) {
+		super(title, description);
+		this.type = Type.CHECKBOX;
+		this.options = options;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionDropdown.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionDropdown.java
@@ -1,0 +1,30 @@
+package com.juwoong.opiniontrade.survey.domain;
+
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue(value = "dropdown")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionDropdown extends Question {
+	@Getter
+	@ElementCollection
+	@CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+	private List<Option> options;
+
+	public QuestionDropdown(String title, String description, List<Option> options) {
+		super(title, description);
+		this.type = Type.DROPDOWN;
+		this.options = options;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionMultipleChoice.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionMultipleChoice.java
@@ -1,0 +1,30 @@
+package com.juwoong.opiniontrade.survey.domain;
+
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue(value = "multiple_choice")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionMultipleChoice extends Question {
+	@Getter
+	@ElementCollection
+	@CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+	private List<Option> options;
+
+	public QuestionMultipleChoice(String title, String description, List<Option> options) {
+		super(title, description);
+		this.type = Type.MULTIPLE_CHOICE;
+		this.options = options;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionParagraph.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/QuestionParagraph.java
@@ -1,0 +1,15 @@
+package com.juwoong.opiniontrade.survey.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+
+@Entity
+@DiscriminatorValue(value = "paragraph")
+@AllArgsConstructor
+public class QuestionParagraph extends Question {
+	public QuestionParagraph(String title, String description) {
+		super(title, description);
+		this.type = Type.PARAGRAPH;
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
@@ -1,0 +1,79 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.juwoong.opiniontrade.survey.api.request.QuestionRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyQuestionService;
+import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
+
+@WebMvcTest(SurveyQuestionController.class)
+class SurveyQuestionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SurveyQuestionService surveyQuestionService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	void createQuestion() throws Exception {
+		// given
+		Long surveyId = 1L;
+		Integer questionOrder = 1;
+		String title = "questionTitle";
+		String description = "questionDescription";
+		Question.Type type = Question.Type.MULTIPLE_CHOICE;
+		List<Option> options = List.of(new Option("Option1"), new Option("Option2"));
+
+		String request = objectMapper.writeValueAsString(
+			new QuestionRequest(
+				questionOrder,
+				title,
+				description,
+				type,
+				options
+			)
+		);
+
+		doNothing().when(surveyQuestionService).createQuestion(
+			eq(surveyId),
+			eq(questionOrder),
+			eq(title),
+			eq(description),
+			eq(type),
+			anyList()
+		);
+
+		// when then
+		mockMvc.perform(post("/surveys/1/questions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated());
+
+		verify(surveyQuestionService, times(1)).createQuestion(
+			eq(surveyId),
+			eq(questionOrder),
+			eq(title),
+			eq(description),
+			eq(type),
+			anyList()
+		);
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
@@ -1,0 +1,48 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyQuestionServiceTest {
+
+	@InjectMocks
+	private SurveyQuestionService surveyQuestionService;
+
+	@Mock
+	private SurveyRepository surveyRepository;
+
+	@Test
+	void createQuestion() {
+		// given
+		Long surveyId = 1L;
+		Integer questionOrder = 1;
+		String title = "title";
+		String description = "description";
+		Question.Type type = Question.Type.MULTIPLE_CHOICE;
+		List<Option> options = List.of(new Option("Option1"), new Option("Option2"));
+
+		// when
+		Survey survey = new Survey(new Creator(1L, "juwoongKim"), "surveytitle", "surveyDescriptions");
+		when(surveyRepository.findById(surveyId)).thenReturn(Optional.of(survey));
+
+		// when then
+		assertThatNoException().isThrownBy(() -> surveyQuestionService.createQuestion(surveyId, questionOrder, title, description, type, options));
+		verify(surveyRepository, times(1)).findById(surveyId);
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.juwoong.opiniontrade.survey.domain.repository;
 
+import static com.juwoong.opiniontrade.survey.domain.Question.Type.*;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.util.List;
@@ -43,14 +44,18 @@ class SurveyRepositoryTest {
 	@Rollback(value = false)
 	void createSurveyQuestion() {
 		// given
+		// 설문지 생성
 		Creator creator = new Creator(1L, "juwoong");
 		Survey survey = new Survey(creator, "title", "description");
 
+		// 질문 생성
 		List<Option> options = List.of(
 			new Option("Question_Option1"),
 			new Option("Question_Option1")
 		);
-		Question question = new Question("title", "description", options);
+		Question.Type type = MULTIPLE_CHOICE;
+		Question question = type.create("title", "description", options);
+
 		Integer questionOrder = 1;
 
 		survey.createQuestion(questionOrder, question);
@@ -74,7 +79,9 @@ class SurveyRepositoryTest {
 			new Option("Question_Option1"),
 			new Option("Question_Option1")
 		);
-		Question question = new Question("title", "description", options);
+		Question.Type type = MULTIPLE_CHOICE;
+		Question question = type.create("title", "description", options);
+
 		Integer questionOrder = 1;
 
 		survey.createQuestion(questionOrder, question);


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문지의 질문 생성 및 수정에 대한 기능을 구현했습니다.
- 다양한 질문 유형 도메인 객체로 표현했습니다.

## 👨‍👩‍👦‍👦 주요 작업 설명
- 구글폼에서는 설문지에 질문항목이 생성 및 수정될때마다 api 요청을 통해 값을 저장합니다.
   이를 참고하여 질문이 설문의 밸류객체가 되지만 api를 별도로 분리했습니다. 
  생성 및 수정 시 객체를 새로 생성하기 때문에 수정과 생성 모두 동일합니다. 
<img width="1303" alt="스크린샷 2024-02-18 오후 7 35 25" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/4461627c-c55e-46ee-ac53-e1ee8dda6fb8">

&nbsp;


- 설문지의 질문 항목은 다양합니다. 모든 항목을 서비스에 반영하진 않지만 질문에 대한 다양성을 
   반영해야한다고 생각했습니다. 
   Question 추상클래스에 유형별로 자식 클래스를 만들었습니다. 
   상속구조에 대한 DB테이블 전략은 단일 테이블 전략을 사용했습니다.
   이유는 전체 항목이 많지 않아 단일 테이블을 사용해도 조회 성능에 부정적이지 않을 것이라 생각했습니다.
<img width="1034" alt="스크린샷 2024-02-18 오후 4 16 11" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/02b9a41e-f354-4af4-a767-97332f50bd20">

&nbsp;

- 다양한 질문에 대한 생성 조회를 한번에 처리하기 위해 enum타입에 함수형 인터페이스를 통해 생성하도록 책임을 할당했습니다. 팩토리 클래스 등 다양한 생성 전략이 있지만 한번 사용해보고 싶었습니다.


## 👨‍👩‍👧‍👧 기타 의견 
- 상속구조로 표현하면서도 enum 타입으로 구분한게 직감적으로 잘못된 방향이라는 생각이 들긴했습니다. 하지만 조회시 어떻게 유혀별로 구별할지 감이 잡히지 않아서 Enum으로 타입을 표현헀습니다. 조회 작업을 구현하면서 필요하다면 개선할 예정입니다.
