### PR TITLE
19 예외 처리 적용

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/global/config/JpaConfiguration.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/config/JpaConfiguration.java
@@ -1,4 +1,4 @@
-package com.juwoong.opiniontrade.config;
+package com.juwoong.opiniontrade.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/juwoong/opiniontrade/global/entity/TimeBaseEntity.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/entity/TimeBaseEntity.java
@@ -1,4 +1,4 @@
-package com.juwoong.opiniontrade.common.entity;
+package com.juwoong.opiniontrade.global.entity;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
 

--- a/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.juwoong.opiniontrade.global.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+	// 404
+	NOT_FOUND_SURVEY(NOT_FOUND, "설문지가 존재하지 않습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorResponse.java
@@ -1,0 +1,32 @@
+package com.juwoong.opiniontrade.global.exception;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public record ErrorResponse(
+	HttpStatus code,
+	String message,
+	List<ArgumentError> errors
+) {
+	@Getter
+	@AllArgsConstructor
+	public static class ArgumentError {
+		String field;
+		String inputValue;
+		String message;
+	}
+
+	public ErrorResponse(HttpStatus code, String message) {
+		this(code, message, null);
+	}
+
+	public ErrorResponse(HttpStatus code, String message, List<ArgumentError> errors) {
+		this.code = code;
+		this.message = message;
+		this.errors = errors;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.juwoong.opiniontrade.global.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// custom exception
+	@ExceptionHandler(OpinionTradeException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(OpinionTradeException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		ErrorResponse errorResponse = new ErrorResponse(errorCode.getHttpStatus(), errorCode.getMessage());
+
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+	}
+
+	// client request exception 400 Error
+	@ExceptionHandler(value = MethodArgumentNotValidException.class)
+	@ResponseStatus(BAD_REQUEST)
+	public ErrorResponse handleArgumentNotValidException(MethodArgumentNotValidException e) {
+		List<ErrorResponse.ArgumentError> argumentErrors = e.getBindingResult().getFieldErrors().stream()
+			.map(fieldError -> new ErrorResponse.ArgumentError(fieldError.getField(),
+				fieldError.getRejectedValue().toString(),
+				fieldError.getDefaultMessage())).toList();
+
+		return new ErrorResponse(BAD_REQUEST, e.getMessage(), argumentErrors);
+	}
+
+	// etc
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	public ErrorResponse handleUnexpectedException(RuntimeException e) {
+		return new ErrorResponse(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getReasonPhrase());
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/global/exception/OpinionTradeException.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/OpinionTradeException.java
@@ -1,0 +1,18 @@
+package com.juwoong.opiniontrade.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OpinionTradeException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public OpinionTradeException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public OpinionTradeException(ErrorCode errorCode, Throwable throwable) {
+		super(errorCode.getMessage(), throwable);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
@@ -1,23 +1,16 @@
 package com.juwoong.opiniontrade.survey.api;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.juwoong.opiniontrade.survey.api.request.RequestInfoRequest;
 import com.juwoong.opiniontrade.survey.api.request.SurveyRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyService;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResponse;
 import com.juwoong.opiniontrade.survey.domain.Creator;
-import com.juwoong.opiniontrade.survey.domain.RequestInfo;
-import com.juwoong.opiniontrade.survey.domain.Respondent;
 
 import jakarta.validation.Valid;
 
@@ -42,17 +35,17 @@ public class SurveyController {
 		return surveyResponse;
 	}
 
-	@PutMapping("/{surveyId}/request")
-	@ResponseStatus(HttpStatus.OK)
-	public void requestSurvey(
-		@PathVariable Long surveyId,
-		@RequestBody RequestInfoRequest requestInfoRequest
-	) {
-
-		RequestInfo requestInfo = requestInfoRequest.requestInfo();
-		List<Respondent> respondents = requestInfoRequest.assignedRespondent();
-		//surveyService.requestSurvey(surveyId, requestInfo, respondents);
-
-	}
+	// @PutMapping("/{surveyId}/request")
+	// @ResponseStatus(HttpStatus.OK)
+	// public void requestSurvey(
+	// 	@PathVariable Long surveyId,
+	// 	@RequestBody RequestInfoRequest requestInfoRequest
+	// ) {
+	//
+	// 	RequestInfo requestInfo = requestInfoRequest.requestInfo();
+	// 	List<Respondent> respondents = requestInfoRequest.assignedRespondent();
+	// 	//surveyService.requestSurvey(surveyId, requestInfo, respondents);
+	//
+	// }
 
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.juwoong.opiniontrade.survey.api.request.QuestionRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyQuestionService;
-import com.juwoong.opiniontrade.survey.application.response.QuestionResponse;
 import com.juwoong.opiniontrade.survey.application.response.QuestionsResponse;
 import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
 
 @RestController
 @RequestMapping(value = "/surveys")
@@ -31,7 +31,7 @@ public class SurveyQuestionController {
 
 	@PostMapping("/{surveyId}/questions")
 	@ResponseStatus(HttpStatus.CREATED)
-	public QuestionResponse createSurveyQuestion(
+	public void createSurveyQuestion(
 		@PathVariable Long surveyId,
 		@RequestBody QuestionRequest questionRequest
 	) {
@@ -40,26 +40,25 @@ public class SurveyQuestionController {
 		String title = questionRequest.title();
 		String description = questionRequest.description();
 		List<Option> options = questionRequest.options();
+		Question.Type type = questionRequest.type();
 
-		QuestionResponse questionResponse = surveyQuestionService.createQuestion(
+		surveyQuestionService.createQuestion(
 			surveyId,
 			questionOrder,
 			title,
 			description,
+			type,
 			options
 		);
-
-		return questionResponse;
 	}
 
 	@GetMapping("/{surveyId}/questions")
 	@ResponseStatus(HttpStatus.OK)
-	public QuestionsResponse getQuestions(@PathVariable Long surveyId){
+	public QuestionsResponse getQuestions(@PathVariable Long surveyId) {
 		QuestionsResponse questionsResponse = surveyQuestionService.getQuestions(surveyId);
 
-		return  questionsResponse;
+		return questionsResponse;
 	}
-
 
 	@DeleteMapping("/{surveyId}/questions/{questionOrder}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.juwoong.opiniontrade.common.entity.TimeBaseEntity;
+import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
@@ -2,7 +2,7 @@ package com.juwoong.opiniontrade.survey.domain;
 
 import java.util.List;
 
-import com.juwoong.opiniontrade.common.entity.TimeBaseEntity;
+import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;

--- a/src/main/java/com/juwoong/opiniontrade/user/domain/User.java
+++ b/src/main/java/com/juwoong/opiniontrade/user/domain/User.java
@@ -3,7 +3,7 @@ package com.juwoong.opiniontrade.user.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.juwoong.opiniontrade.common.entity.TimeBaseEntity;
+import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyControllerTest.java
@@ -3,6 +3,7 @@ package com.juwoong.opiniontrade.survey.api;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
@@ -78,7 +79,7 @@ class SurveyControllerTest {
 			.andExpect(
 				result -> assertThat(result.getResolvedException()).isInstanceOf(MethodArgumentNotValidException.class)
 			)
-			.andExpect(status().isBadRequest());
+			.andExpect(status().isBadRequest())
+			.andDo(print());
 	}
-
 }


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 프로젝트에 사용할 커스텀 에러코드와 예외를 구현했습니다.
- 프로젝트에서 사용할 전역 예외 핸들러와 예외 반환값을 구현했습니다. 

## 👨‍👩‍👦‍👦 주요 작업 설명
- 예외 핸들러는 커스텀 예외 처리, 사용자 입력값으로 인한 400에러, 커스텀을 제외한 나며지 예외 총 3가지로 구성했습니다.
- MethodArgumentNotValidException 인 경우 ResultBing을 사용해서 검증에 실패한 필드값, 입력값, 이유를 같이 반환할 수 있도록 구현했습니다. 
<img width="857" alt="스크린샷 2024-02-19 오전 1 29 18" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/55552178-d0bb-4930-9eb4-40e717af9e72">


## 👨‍👩‍👧‍👧 기타 의견 
- 없음
