### PR TITLE
질문 삭제 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -45,7 +45,7 @@ public class SurveyQuestionController {
 		@Valid @RequestBody QuestionRequest.Delete request
 	) {
 		Integer questionOrder = request.questionOrder();
-		surveyQuestionService.removeSurvey(surveyId, questionOrder);
+		surveyQuestionService.removeQuestion(surveyId, questionOrder);
 	}
 
 	//

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -1,6 +1,7 @@
 package com.juwoong.opiniontrade.survey.api;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,13 +29,23 @@ public class SurveyQuestionController {
 	) {
 		surveyQuestionService.createQuestion(
 			surveyId,
-			request.questionOrder(),
 			request.type(),
 			request.title(),
 			request.description(),
 			request.options()
 		);
 	}
+
+	@DeleteMapping("/{surveyId}/questions")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteSurveyQuestion(
+		@PathVariable Long surveyId,
+		@RequestBody QuestionRequest.Delete request
+	) {
+		Integer questionOrder = request.questionOrder();
+		surveyQuestionService.removeSurvey(surveyId, questionOrder);
+	}
+
 	//
 	// @GetMapping("/{surveyId}/questions")
 	// @ResponseStatus(HttpStatus.OK)
@@ -44,14 +55,6 @@ public class SurveyQuestionController {
 	// 	return questionsResponse;
 	// }
 	//
-	// @DeleteMapping("/{surveyId}/questions/{questionOrder}")
-	// @ResponseStatus(HttpStatus.NO_CONTENT)
-	// public void deleteSurveyQuestion(
-	// 	@PathVariable Long surveyId,
-	// 	@PathVariable Integer questionOrder
-	// ) {
-	// 	surveyQuestionService.removeSurvey(surveyId, questionOrder);
-	// }
 	//
 	// @PutMapping("/{surveyId}/questions/change-order")
 	// @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.juwoong.opiniontrade.survey.api.request.QuestionRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyQuestionService;
 
+import jakarta.validation.Valid;
+
 @RestController
 @RequestMapping(value = "/surveys")
 public class SurveyQuestionController {
@@ -25,7 +27,7 @@ public class SurveyQuestionController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public void createSurveyQuestion(
 		@PathVariable Long surveyId,
-		@RequestBody QuestionRequest.Create request
+		@Valid @RequestBody QuestionRequest.Create request
 	) {
 		surveyQuestionService.createQuestion(
 			surveyId,
@@ -40,7 +42,7 @@ public class SurveyQuestionController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteSurveyQuestion(
 		@PathVariable Long surveyId,
-		@RequestBody QuestionRequest.Delete request
+		@Valid @RequestBody QuestionRequest.Delete request
 	) {
 		Integer questionOrder = request.questionOrder();
 		surveyQuestionService.removeSurvey(surveyId, questionOrder);

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
@@ -5,13 +5,22 @@ import java.util.List;
 import com.juwoong.opiniontrade.survey.domain.Option;
 import com.juwoong.opiniontrade.survey.domain.Question;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public sealed interface QuestionRequest {
 	record Create(
-		Integer questionOrder,
-		String title,
-		String description,
-		Question.Type type,
-		List<Option> options
+		@Size(min = 0, max = 50) String title,
+		@Size(min = 0, max = 200) String description,
+		@NotNull Question.Type type,
+		@NotNull List<Option> options
+	) implements QuestionRequest {
+	}
+
+	record Delete(
+		@Min(value = 1, message = "QuestionOrder must be 1 or greater")
+		Integer questionOrder
 	) implements QuestionRequest {
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
@@ -19,8 +19,7 @@ public sealed interface QuestionRequest {
 	}
 
 	record Delete(
-		@Min(value = 1, message = "QuestionOrder must be 1 or greater")
-		Integer questionOrder
+		@Min(value = 1) Integer questionOrder
 	) implements QuestionRequest {
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -23,7 +23,6 @@ public class SurveyQuestionService {
 	@Transactional
 	public void createQuestion(
 		Long surveyId,
-		Integer questionOrder,
 		Question.Type type,
 		String title,
 		String description,
@@ -34,14 +33,15 @@ public class SurveyQuestionService {
 
 		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
 
-		survey.createQuestion(questionOrder, question);
+		survey.createQuestion(question);
 	}
 
-	// @Transactional
-	// public void removeSurvey(Long surveyId, Integer questionOrder) {
-	// 	// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-	// 	// survey.removeQuestion(questionOrder);
-	// }
+	@Transactional
+	public void removeSurvey(Long surveyId, Integer questionOrder) {
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		survey.removeQuestion(questionOrder);
+	}
+
 	//
 	// @Transactional
 	// public void changeOrder(Long surveyId, Integer oneOrder, Integer anotherOrder) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -1,10 +1,13 @@
 package com.juwoong.opiniontrade.survey.application;
 
+import static com.juwoong.opiniontrade.global.exception.ErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.juwoong.opiniontrade.global.exception.OpinionTradeException;
 import com.juwoong.opiniontrade.survey.domain.Option;
 import com.juwoong.opiniontrade.survey.domain.Question;
 import com.juwoong.opiniontrade.survey.domain.QuestionInfo;
@@ -31,14 +34,16 @@ public class SurveyQuestionService {
 		QuestionInfo questionInfo = QuestionInfo.init(title, description);
 		Question question = Question.init(type, questionInfo, options);
 
-		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		Survey survey = surveyRepository.findById(surveyId)
+			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 
 		survey.createQuestion(question);
 	}
 
 	@Transactional
-	public void removeSurvey(Long surveyId, Integer questionOrder) {
-		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+	public void removeQuestion(Long surveyId, Integer questionOrder) {
+		Survey survey = surveyRepository.findById(surveyId)
+			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 		survey.removeQuestion(questionOrder);
 	}
 

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Question.java
@@ -16,8 +16,10 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "questions")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -1,9 +1,8 @@
 package com.juwoong.opiniontrade.survey.domain;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
 
@@ -49,7 +48,7 @@ public class Survey extends TimeBaseEntity {
 
 	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
 	@JoinColumn(name = "survey_id")
-	private final Map<Integer, Question> questions = new HashMap<>();
+	private final List<Question> questions = new LinkedList<>();
 
 	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
 	@JoinColumn(name = "survey_id")
@@ -67,8 +66,8 @@ public class Survey extends TimeBaseEntity {
 		this.surveyInfo = surveyInfo;
 	}
 
-	public void createQuestion(Integer order, Question question) {
-		questions.put(order, question);
+	public void createQuestion(Question question) {
+		questions.add(question);
 	}
 
 	public void changeQuestionOrder(Integer oneOrder, Integer anotherOrder) {
@@ -78,6 +77,8 @@ public class Survey extends TimeBaseEntity {
 	}
 
 	public void deleteQuestion(Integer order) {
+		Integer index = order - 1;
+		questions.remove(index);
 	}
 
 	public void receiveSurveyResult(SurveyResult surveyResult) {

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,6 +19,7 @@ import com.juwoong.opiniontrade.survey.domain.Question;
 import com.juwoong.opiniontrade.survey.domain.Survey;
 import com.juwoong.opiniontrade.survey.domain.SurveyInfo;
 import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
 
 @ExtendWith(MockitoExtension.class)
 class SurveyQuestionServiceTest {
@@ -47,9 +49,25 @@ class SurveyQuestionServiceTest {
 
 		// when then
 		assertThatNoException().isThrownBy(
-			() -> surveyQuestionService.createQuestion(surveyId, questionOrder, Question.Type.MULTIPLE_CHOICE,
+			() -> surveyQuestionService.createQuestion(surveyId, Question.Type.MULTIPLE_CHOICE,
 				title, description, options));
 
 		verify(surveyRepository, times(1)).findById(anyLong());
 	}
+
+	@Test
+	@DisplayName("질문 삭제에 성공한다.")
+	void deleteQuestions_Success_With_NoExceptions(){
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		Integer questionOrder = 1;
+		Long surveyId = 1L;
+		when(surveyRepository.findById(anyLong())).thenReturn(Optional.of(survey));
+
+		// when then
+		assertThatNoException().isThrownBy(
+			() -> surveyQuestionService.removeQuestion(surveyId, questionOrder));
+
+		verify(surveyRepository, times(1)).findById(anyLong());
+	}
+
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/domain/SurveyTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/domain/SurveyTest.java
@@ -1,0 +1,34 @@
+package com.juwoong.opiniontrade.survey.domain;
+
+import static com.juwoong.opiniontrade.survey.fixture.QuestionFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.juwoong.opiniontrade.survey.fixture.QuestionFixture;
+import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
+
+class SurveyTest {
+	@Test
+	@DisplayName("특정 번호를 통해 질문을 삭제하면 뒤의 질문 순서가 순서대로 채워진다.")
+	void subsequentQuestion_Filled_Sequentially_When_Specific_Question_Is_Deleted() {
+		// given
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+
+		List<Question> questions = List.of(
+			QuestionFixture.PARAGRAPH.getInstance(),
+			QuestionFixture.PARAGRAPH.getInstance(),
+			MULTIPLE_CHOICE.getInstance(),
+			QuestionFixture.PARAGRAPH.getInstance());
+		questions.forEach(question -> survey.createQuestion(question));
+
+		// when
+		survey.deleteQuestion(2);
+
+		// then
+		assertThat(survey.getQuestions().get(2).getType().name()).isEqualTo(MULTIPLE_CHOICE.name());
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/fixture/QuestionFixture.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/fixture/QuestionFixture.java
@@ -1,0 +1,30 @@
+package com.juwoong.opiniontrade.survey.fixture;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.Option;
+import com.juwoong.opiniontrade.survey.domain.Question;
+import com.juwoong.opiniontrade.survey.domain.QuestionInfo;
+
+public enum QuestionFixture {
+	MULTIPLE_CHOICE(Question.Type.MULTIPLE_CHOICE, "title", "MULTIPLE_CHOICE", List.of("Red", "Blue", "greem")),
+	PARAGRAPH(Question.Type.PARAGRAPH, "title", "PARAGRAPH", List.of());
+
+	private Question.Type type;
+	private String title;
+	private String description;
+	private List<String> optionNames;
+
+	QuestionFixture(Question.Type type, String title, String description, List<String> optionNames) {
+		this.type = type;
+		this.title = title;
+		this.description = description;
+		this.optionNames = optionNames;
+	}
+
+	public Question getInstance() {
+		QuestionInfo questionInfo = QuestionInfo.init(title, description);
+		List<Option> options = optionNames.stream().map(optionName -> Option.init(optionName)).toList();
+		return Question.init(type, questionInfo, options);
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyFixture.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyFixture.java
@@ -1,0 +1,25 @@
+package com.juwoong.opiniontrade.survey.fixture;
+
+import com.juwoong.opiniontrade.survey.domain.Creator;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.SurveyInfo;
+
+public enum SurveyFixture {
+	SURVEY(1L, "title", "descriptions");
+
+	private Long creatorId;
+	private String title;
+	private String description;
+
+	SurveyFixture(Long creatorId, String title, String description) {
+		this.creatorId = creatorId;
+		this.title = title;
+		this.description = description;
+	}
+
+	public Survey getInstance() {
+		Creator creator = Creator.init(creatorId);
+		SurveyInfo surveyInfo = SurveyInfo.init(title, description);
+		return Survey.init(creator, surveyInfo);
+	}
+}


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문지 질문 삭제 기능을 구현했습니다.
- 질문은 설문지 밸류 객체이며 보관할 필요가 없다고 생각하여  hard delete를 적용했습니다.

## 👨‍👩‍👦‍👦 주요 작업 설명
- 설문지에서 질문 순서와 질문 관계 표현을 Map 에서 LinkedList 자료구조로 변경했습니다. 
  1번 질문이 삭제되었을 때 뒤에 있는 질문이 순서대로 채워지기 위해서 입니다.
  이에 따라 질문 수정 기능이 별도로 추가 됩니다. (기존에는 질문 생성시 번호와 함께 넣었기 때문)

- 테스트 코드에서 Fixture가 중복되는 것을 방지해서 enum 인스턴스로 필요한 Fixture를 만들었습니다.
- Fixture Monkey 도입을 고려했지만, 아직까진 fixture 값을 지정해서 테스트하는 것 만으로도 충분했습니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 없음
