### PR TITLE
질문 순서 변경 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -66,7 +66,7 @@ public class SurveyQuestionController {
 	}
 
 	@PutMapping("/{surveyId}/questions/change-order")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@ResponseStatus(HttpStatus.OK)
 	public void changeQuestionOrder(
 		@PathVariable Long surveyId,
 		@Valid @RequestBody QuestionRequest.UpdateQuestionOrder request

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionController.java
@@ -65,24 +65,14 @@ public class SurveyQuestionController {
 		);
 	}
 
-
-	//
-	// @GetMapping("/{surveyId}/questions")
-	// @ResponseStatus(HttpStatus.OK)
-	// public QuestionsResponse getQuestions(@PathVariable Long surveyId) {
-	// 	QuestionsResponse questionsResponse = surveyQuestionService.getQuestions(surveyId);
-	//
-	// 	return questionsResponse;
-	// }
-	//
-	//
-	// @PutMapping("/{surveyId}/questions/change-order")
-	// @ResponseStatus(HttpStatus.NO_CONTENT)
-	// public void changeQuestionOrder(
-	// 	@PathVariable Long surveyId,
-	// 	@RequestParam Integer oneOrder,
-	// 	@RequestParam Integer anotherOrder
-	// ) {
-	// 	surveyQuestionService.changeOrder(surveyId, oneOrder, anotherOrder);
-	// }
+	@PutMapping("/{surveyId}/questions/change-order")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void changeQuestionOrder(
+		@PathVariable Long surveyId,
+		@Valid @RequestBody QuestionRequest.UpdateQuestionOrder request
+	) {
+		Integer oneOrder = request.oneQuestionOrder();
+		Integer anotherOrder = request.anotherQuestionOrder();
+		surveyQuestionService.changeOrder(surveyId, oneOrder, anotherOrder);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/QuestionRequest.java
@@ -31,4 +31,10 @@ public sealed interface QuestionRequest {
 		@Min(value = 1) Integer questionOrder
 	) implements QuestionRequest {
 	}
+
+	record UpdateQuestionOrder(
+		@Min(value = 1) Integer oneQuestionOrder,
+		@Min(value = 1) Integer anotherQuestionOrder
+	) implements QuestionRequest {
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -61,17 +61,20 @@ public class SurveyQuestionService {
 		survey.updateQuestion(questionOrder, question);
 	}
 
+	@Transactional
+	public void changeOrder(Long surveyId, Integer oneOrder, Integer anotherOrder) {
+		Survey survey = findSurveyById(surveyId);
+		survey.changeQuestionOrder(oneOrder, anotherOrder);
+	}
+
 	private Survey findSurveyById(Long id) {
 		return surveyRepository.findById(id)
 			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 	}
 
-	//
-	// @Transactional
-	// public void changeOrder(Long surveyId, Integer oneOrder, Integer anotherOrder) {
-	// 	// Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-	// 	// survey.changeQuestionOrder(oneOrder, anotherOrder);
-	// }
+
+
+
 	//
 	// public QuestionsResponse getQuestions(Long surveyId) {
 	// 	Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -76,6 +76,11 @@ public class Survey extends TimeBaseEntity {
 	}
 
 	public void changeQuestionOrder(Integer oneOrder, Integer anotherOrder) {
+		Question oneQuestion = questions.get(oneOrder);
+		Question anotherQuestion = questions.get(anotherOrder);
+
+		questions.set(anotherOrder, oneQuestion);
+		questions.set(oneOrder, anotherQuestion);
 	}
 
 	public void removeQuestion(Integer order) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -76,11 +76,13 @@ public class Survey extends TimeBaseEntity {
 	}
 
 	public void changeQuestionOrder(Integer oneOrder, Integer anotherOrder) {
-		Question oneQuestion = questions.get(oneOrder);
-		Question anotherQuestion = questions.get(anotherOrder);
+		Integer oneIndex = oneOrder - 1;
+		Integer anotherIndex = anotherOrder - 1;
+		Question oneQuestion = questions.get(oneIndex);
+		Question anotherQuestion = questions.get(anotherIndex);
 
-		questions.set(anotherOrder, oneQuestion);
-		questions.set(oneOrder, anotherQuestion);
+		questions.set(anotherIndex, oneQuestion);
+		questions.set(oneIndex, anotherQuestion);
 	}
 
 	public void removeQuestion(Integer order) {

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
@@ -99,13 +99,14 @@ class SurveyQuestionControllerTest {
 
 		ResultActions result = mockMvc.perform(delete("/surveys/{surveyId}/questions", surveyId)
 			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(request)));
 
 		result.andExpect(status().isBadRequest());
 	}
 
 	@Test
-	@DisplayName("설문지 질문 수정시  204 상태값과 반환값 없음을 응답 한다")
+	@DisplayName("설문지 질문 수정시 204 상태값과 반환값 없음을 응답 한다")
 	void updateQuestion() throws Exception {
 		// given
 		Long surveyId = 1L;
@@ -135,11 +136,12 @@ class SurveyQuestionControllerTest {
 		);
 
 		// when then
-		mockMvc.perform(put("/surveys/{surveyId}/questions", surveyId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(request)
-				.accept(MediaType.APPLICATION_JSON))
-			.andExpect(status().isNoContent());
+		ResultActions result = mockMvc.perform(put("/surveys/{surveyId}/questions", surveyId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(request));
+
+		result.andExpect(status().isNoContent());
 
 		verify(surveyQuestionService, times(1)).updateQuestion(
 			anyLong(),
@@ -149,5 +151,22 @@ class SurveyQuestionControllerTest {
 			anyString(),
 			anyList()
 		);
+	}
+
+	@Test
+	@DisplayName("질문 순서 변경 완료 시 200 상태코드와 반환값 없음을 응답 한다")
+	void changeQuestionOrder() throws Exception {
+		Long surveyId = 1L;
+		QuestionRequest.UpdateQuestionOrder request = new QuestionRequest.UpdateQuestionOrder(1, 2);
+		doNothing().when(surveyQuestionService).changeOrder(anyLong(), anyInt(), anyInt());
+
+		ResultActions result = mockMvc.perform(put("/surveys/{surveyId}/questions/change-order", surveyId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)));
+
+		result.andExpect(status().isOk());
+
+		verify(surveyQuestionService, times(1)).changeOrder(anyLong(), anyInt(), anyInt());
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionServiceTest.java
@@ -97,4 +97,21 @@ class SurveyQuestionServiceTest {
 
 		verify(surveyRepository, times(1)).findById(anyLong());
 	}
+
+	@Test
+	@DisplayName("질문 순서 변경에 성공 한다.")
+	void changeQuestionOrder_Success() {
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		Question paragraph = QuestionFixture.PARAGRAPH.getInstance();
+		Question multiple = QuestionFixture.MULTIPLE_CHOICE.getInstance();
+
+		survey.createQuestion(paragraph);
+		survey.createQuestion(multiple);
+
+		when(surveyRepository.findById(anyLong())).thenReturn(Optional.of(survey));
+
+		surveyQuestionService.changeOrder(1L, 1, 2);
+
+		verify(surveyRepository, times(1)).findById(anyLong());
+	}
 }


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문지의 질문 순셔 변경 기능을 구현했습니다.

## 👨‍👩‍👦‍👦 주요 작업 설명
- 질문을 저장하는 linkedList 에서 인덱스에 해당하는 질문을 뽑아 swap하는 방식으로 구현했습니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 없음
