### PR TITLE
설문 결과 생성기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -1,0 +1,35 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyResultService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping(value = "/surveys")
+@RequiredArgsConstructor
+public class SurveyResultController {
+	private final SurveyResultService surveyResultService;
+
+	@PostMapping("/{surveyId}/surveyResult")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createSurveyResult(
+		@PathVariable Long surveyId,
+		@RequestBody ResultRequest.Create request
+	) {
+		Long respondentId = request.respondentId();
+		List<ResultRequest.Answer> answers = request.answers();
+
+		surveyResultService.createSurveyResult(surveyId, respondentId, answers);
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/ResultRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/ResultRequest.java
@@ -1,0 +1,19 @@
+package com.juwoong.opiniontrade.survey.api.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public sealed interface ResultRequest {
+	record Create(
+		@NotNull Long respondentId,
+		List<Answer> answers
+	) implements ResultRequest {
+	}
+
+	record Answer(
+		@NotNull Long questionId,
+		@NotNull String content
+	) implements ResultRequest {
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyQuestionService.java
@@ -71,15 +71,4 @@ public class SurveyQuestionService {
 		return surveyRepository.findById(id)
 			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 	}
-
-
-
-
-	//
-	// public QuestionsResponse getQuestions(Long surveyId) {
-	// 	Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-	// 	Map<Integer, Question> questions = survey.findQuestionWithOrder();
-	//
-	// 	return new QuestionsResponse(questions);
-	// }
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -1,0 +1,40 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import static com.juwoong.opiniontrade.global.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.juwoong.opiniontrade.global.exception.OpinionTradeException;
+import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyResultService {
+	private final SurveyRepository surveyRepository;
+
+	public void createSurveyResult(Long surveyId, Long respondentId, List<ResultRequest.Answer> answerInfo) {
+		Survey survey = findSurveyById(surveyId);
+
+		Respondent respondent = Respondent.init(respondentId);
+		List<Answer> answers = answerInfo.stream()
+			.map(answer -> Answer.init(answer.questionId(), answer.content()))
+			.toList();
+
+		SurveyResult surveyResult = SurveyResult.init(respondent, answers);
+		survey.receiveSurveyResult(surveyResult);
+	}
+
+	private Survey findSurveyById(Long id) {
+		return surveyRepository.findById(id)
+			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Respondent.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Respondent.java
@@ -13,10 +13,7 @@ public class Respondent {
 	@Column(name = "respondentId")
 	private Long respondentId;
 
-	@Column(name = "respondent_name")
-	private String name;
-
-	public static Respondent init(Long respondentId, String name) {
-		return new Respondent(respondentId, name);
+	public static Respondent init(Long respondentId) {
+		return new Respondent(respondentId);
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyQuestionControllerTest.java
@@ -63,8 +63,7 @@ class SurveyQuestionControllerTest {
 		// when then
 		mockMvc.perform(post("/surveys/{surveyId}/questions", surveyId)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(request)
-				.accept(MediaType.APPLICATION_JSON))
+				.content(request))
 			.andExpect(status().isCreated());
 
 		verify(surveyQuestionService, times(1)).createQuestion(
@@ -99,7 +98,6 @@ class SurveyQuestionControllerTest {
 
 		ResultActions result = mockMvc.perform(delete("/surveys/{surveyId}/questions", surveyId)
 			.contentType(MediaType.APPLICATION_JSON)
-			.accept(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(request)));
 
 		result.andExpect(status().isBadRequest());
@@ -138,7 +136,6 @@ class SurveyQuestionControllerTest {
 		// when then
 		ResultActions result = mockMvc.perform(put("/surveys/{surveyId}/questions", surveyId)
 			.contentType(MediaType.APPLICATION_JSON)
-			.accept(MediaType.APPLICATION_JSON)
 			.content(request));
 
 		result.andExpect(status().isNoContent());
@@ -162,7 +159,6 @@ class SurveyQuestionControllerTest {
 
 		ResultActions result = mockMvc.perform(put("/surveys/{surveyId}/questions/change-order", surveyId)
 			.contentType(MediaType.APPLICATION_JSON)
-			.accept(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(request)));
 
 		result.andExpect(status().isOk());

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
@@ -1,0 +1,52 @@
+package com.juwoong.opiniontrade.survey.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
+import com.juwoong.opiniontrade.survey.application.SurveyResultService;
+
+@WebMvcTest(SurveyResultController.class)
+class SurveyResultControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SurveyResultService surveyResultService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("설문결과 성공시 204 상태 코드와 반환값 없음을 응답 한다")
+	void createSurveyResult_Success() throws Exception {
+		Long surveyId = 1L;
+		Long respondentId = 1L;
+		List<ResultRequest.Answer> answer = List.of(new ResultRequest.Answer(1L, "content"));
+		ResultRequest.Create request = new ResultRequest.Create(respondentId, answer);
+
+		doNothing().when(surveyResultService).createSurveyResult(anyLong(), anyLong(), anyList());
+
+		ResultActions result = mockMvc.perform(
+			post("/surveys/{surveyId}/surveyResult", surveyId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+
+		result.andExpect(status().isCreated());
+
+		verify(surveyResultService, times(1)).createSurveyResult(anyLong(), anyLong(), anyList());
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
@@ -1,0 +1,45 @@
+package com.juwoong.opiniontrade.survey.application;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
+import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyResultServiceTest {
+	@InjectMocks
+	private SurveyResultService surveyResultService;
+
+	@Mock
+	private SurveyRepository surveyRepository;
+
+	@Test
+	@DisplayName("설문 결과 생성에 성공 한다.")
+	void createSurveyResult_Success() {
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		when(surveyRepository.findById(anyLong())).thenReturn(Optional.of(survey));
+
+		Long surveyId = 1L;
+		Long respondentId = 1L;
+		List<ResultRequest.Answer> answer = List.of(
+			new ResultRequest.Answer(1L, "content")
+		);
+
+		surveyResultService.createSurveyResult(surveyId, respondentId, answer);
+
+		verify(surveyRepository, times(1)).findById(anyLong());
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyResultFixture.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyResultFixture.java
@@ -1,0 +1,26 @@
+package com.juwoong.opiniontrade.survey.fixture;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.Respondent;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+
+public enum SurveyResultFixture {
+	SURVEY_RESULT(1l, 1l, "content");
+	private Long respondentId;
+	private Long questionId;
+	private String answerContent;
+
+	public SurveyResult getInstance() {
+		Respondent respondent = Respondent.init(respondentId);
+		Answer answer = Answer.init(questionId, answerContent);
+		return SurveyResult.init(respondent, List.of(answer));
+	}
+
+	SurveyResultFixture(Long respondentId, Long questionId, String answerContent) {
+		this.respondentId = respondentId;
+		this.questionId = questionId;
+		this.answerContent = answerContent;
+	}
+}


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문 결과 생성 기능을 구현했습니다. 

## 👨‍👩‍👦‍👦 주요 작업 설명
- 질문과 마찬가지로 설문지의 value 역할을 하도록 합니다.  (모든 응답 내용을 한번에 처리) 

## 👨‍👩‍👧‍👧 기타 의견 
- 없음
