### PR TITLE
설문 결과 수정기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 	// 404
-	NOT_FOUND_SURVEY(NOT_FOUND, "설문지가 존재하지 않습니다.");
+	NOT_FOUND_SURVEY(NOT_FOUND, "설문지가 존재하지 않습니다."),
+	NOT_FOUND_SURVEY_RESULT(NOT_FOUND, "설문 결과가 존재하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -31,5 +32,17 @@ public class SurveyResultController {
 		List<ResultRequest.Answer> answers = request.answers();
 
 		surveyResultService.createSurveyResult(surveyId, respondentId, answers);
+	}
+
+	@PutMapping("/{surveyId}/surveyResult")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void createSurveyResult(
+		@PathVariable Long surveyId,
+		@RequestBody ResultRequest.Update request
+	) {
+		Long respondentId = request.respondentId();
+		List<ResultRequest.Answer> answers = request.answers();
+
+		surveyResultService.updateSurveyResult(surveyId, respondentId, answers);
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/request/ResultRequest.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/request/ResultRequest.java
@@ -11,6 +11,12 @@ public sealed interface ResultRequest {
 	) implements ResultRequest {
 	}
 
+	record Update(
+		@NotNull Long respondentId,
+		List<Answer> answers
+	) implements ResultRequest {
+	}
+
 	record Answer(
 		@NotNull Long questionId,
 		@NotNull String content

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -5,6 +5,7 @@ import static com.juwoong.opiniontrade.global.exception.ErrorCode.*;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.global.exception.OpinionTradeException;
 import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
@@ -17,10 +18,12 @@ import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SurveyResultService {
 	private final SurveyRepository surveyRepository;
 
+	@Transactional
 	public void createSurveyResult(Long surveyId, Long respondentId, List<ResultRequest.Answer> answerInfo) {
 		Survey survey = findSurveyById(surveyId);
 
@@ -33,8 +36,18 @@ public class SurveyResultService {
 		survey.receiveSurveyResult(surveyResult);
 	}
 
+	@Transactional
+	public void updateSurveyResult(Long surveyId, Long respondentId, List<ResultRequest.Answer> answerInfo) {
+		Survey survey = findSurveyById(surveyId);
+
+		List<Answer> answers = answerInfo.stream()
+			.map(answer -> Answer.init(answer.questionId(), answer.content()))
+			.toList();
+
+		survey.updateSurveyResult(respondentId, answers);
+	}
+
 	private Survey findSurveyById(Long id) {
-		return surveyRepository.findById(id)
-			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
+		return surveyRepository.findById(id).orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Respondent.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Respondent.java
@@ -4,8 +4,10 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -1,10 +1,13 @@
 package com.juwoong.opiniontrade.survey.domain;
 
+import static com.juwoong.opiniontrade.global.exception.ErrorCode.*;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
+import com.juwoong.opiniontrade.global.exception.OpinionTradeException;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -92,6 +95,16 @@ public class Survey extends TimeBaseEntity {
 
 	public void receiveSurveyResult(SurveyResult surveyResult) {
 		surveyResults.add(surveyResult);
+	}
+
+	public void updateSurveyResult(Long surveyResultId, List<Answer> answers) {
+		SurveyResult result = surveyResults.stream()
+			.filter(surveyResult -> surveyResult.getRespondent().getRespondentId().longValue()
+				== surveyResultId.longValue())
+			.findFirst()
+			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY_RESULT));
+
+		result.updateAnswers(answers);
 	}
 
 	public SurveyResult getSurveyResultByRespondent(Respondent respondent) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "survey-results")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -40,7 +41,8 @@ public class SurveyResult extends TimeBaseEntity {
 		return new SurveyResult(null, respondent, answers);
 	}
 
-	public void createAnswer(Answer answer) {
-		answers.add(answer);
+	public void updateAnswers(List<Answer> answers) {
+		this.answers = answers;
 	}
+
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
@@ -31,7 +31,7 @@ class SurveyResultControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Test
-	@DisplayName("설문결과 성공시 204 상태 코드와 반환값 없음을 응답 한다")
+	@DisplayName("설문결과 생성 성공시 201 상태 코드와 반환값 없음을 응답 한다")
 	void createSurveyResult_Success() throws Exception {
 		Long surveyId = 1L;
 		Long respondentId = 1L;
@@ -48,5 +48,25 @@ class SurveyResultControllerTest {
 		result.andExpect(status().isCreated());
 
 		verify(surveyResultService, times(1)).createSurveyResult(anyLong(), anyLong(), anyList());
+	}
+
+	@Test
+	@DisplayName("설문결과 생성 성공시 204 상태 코드와 반환값 없음을 응답 한다")
+	void updateSurveyResult_Success() throws Exception {
+		Long surveyId = 1L;
+		Long respondentId = 1L;
+		List<ResultRequest.Answer> answer = List.of(new ResultRequest.Answer(1L, "content"));
+		ResultRequest.Update request = new ResultRequest.Update(respondentId, answer);
+
+		doNothing().when(surveyResultService).updateSurveyResult(anyLong(), anyLong(), anyList());
+
+		ResultActions result = mockMvc.perform(
+			put("/surveys/{surveyId}/surveyResult", surveyId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+
+		result.andExpect(status().isNoContent());
+
+		verify(surveyResultService, times(1)).updateSurveyResult(anyLong(), anyLong(), anyList());
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
@@ -15,8 +15,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
 import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
 import com.juwoong.opiniontrade.survey.domain.repository.SurveyRepository;
 import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
+import com.juwoong.opiniontrade.survey.fixture.SurveyResultFixture;
 
 @ExtendWith(MockitoExtension.class)
 class SurveyResultServiceTest {
@@ -39,6 +41,25 @@ class SurveyResultServiceTest {
 		);
 
 		surveyResultService.createSurveyResult(surveyId, respondentId, answer);
+
+		verify(surveyRepository, times(1)).findById(anyLong());
+	}
+
+	@Test
+	@DisplayName("설문 결과 수정에 성공 한다.")
+	void updateSurveyResult_Success() {
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		SurveyResult surveyResult = SurveyResultFixture.SURVEY_RESULT.getInstance();
+		survey.receiveSurveyResult(surveyResult);
+		when(surveyRepository.findById(anyLong())).thenReturn(Optional.of(survey));
+
+		Long surveyId = 1L;
+		Long respondentId = 1L;
+		List<ResultRequest.Answer> answer = List.of(
+			new ResultRequest.Answer(1L, "updateContent")
+		);
+
+		surveyResultService.updateSurveyResult(surveyId, respondentId, answer);
 
 		verify(surveyRepository, times(1)).findById(anyLong());
 	}


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 제출한 설문 결과를 수정하는 기능을 구현했습니다.

## 👨‍👩‍👦‍👦 주요 작업 설명
- 기존 계획은 설문 결과 자체를 지우고 삭제하는 기능이였습니다.  
- 하지만 무조건 value 역할을 한다고 해서 불변을 가지기보다 필요하다면 속성을 변경하는 기능도 괜찮다고 생각했습니다.
- 특히 중첩 valuecollection 불가로 설문결과가 엔티티로 표현되었기 때문에 지우고 삭제하면 매번 식별자가 증가합니다.
  이는 불필요한 사항이라 생각했습니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 한편으로는 설문지 도메인에 억지로 설문 결과를 넣은 것 같기도합니다. 
- 설문 결과 수정 시 별도로 분리되었다면  id값으로 바로 조회 할 수 있으나 현재는 반복문을 통해 찾고 있습니다. 
- 부하테스트를 수행하면서 성능 차이가 크다면 분리하는 것도 고려할 에정입니다.

