### PR TITLE
설문지 전체 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,12 @@ repositories {
 }
 
 dependencies {
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // bean validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/juwoong/opiniontrade/global/config/JpaConfiguration.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/config/JpaConfiguration.java
@@ -1,9 +1,22 @@
 package com.juwoong.opiniontrade.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfiguration {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory queryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyController.java
@@ -1,5 +1,10 @@
 package com.juwoong.opiniontrade.survey.api;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -7,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,4 +61,19 @@ public class SurveyController {
 		return surveyService.getSurvey(surveyId);
 	}
 
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public Slice<SurveyResponse.Get> getSurveys(
+		@RequestParam Long userId,
+		@RequestParam(required = false) LocalDateTime cursorTime,
+		@RequestParam(defaultValue = "0") Long cursorId,
+		@RequestParam(defaultValue = "10") Integer size
+	) {
+		if (cursorTime == null) {
+			cursorTime = LocalDateTime.now();
+		}
+		Pageable pageable = PageRequest.of(0, size);
+
+		return surveyService.getSurveys(userId, cursorTime, cursorId, pageable);
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyService.java
@@ -2,6 +2,12 @@ package com.juwoong.opiniontrade.survey.application;
 
 import static com.juwoong.opiniontrade.global.exception.ErrorCode.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,5 +52,13 @@ public class SurveyService {
 			.orElseThrow(() -> new OpinionTradeException(NOT_FOUND_SURVEY));
 
 		return new SurveyResponse.GetDetail(survey);
+	}
+
+	public Slice<SurveyResponse.Get> getSurveys(Long userId, LocalDateTime cursorTime, Long cursorId,
+		Pageable pageable) {
+		Slice<Survey> surveys = surveyRepository.getSurveysByCursor(userId, cursorId, cursorTime, pageable);
+		List<SurveyResponse.Get> response = surveys.getContent().stream().map(SurveyResponse.Get::new).toList();
+
+		return new SliceImpl(response, surveys.getPageable(), surveys.hasNext());
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResponse.java
@@ -28,4 +28,20 @@ public sealed interface SurveyResponse {
 			);
 		}
 	}
+
+	record Get(
+		Long surveyId,
+		String title,
+		String description,
+		Survey.Status surveyStatus
+	) implements SurveyResponse {
+		public Get(Survey survey) {
+			this(
+				survey.getId(),
+				survey.getSurveyInfo().getTitle(),
+				survey.getSurveyInfo().getDescription(),
+				survey.getSurveyStatus()
+			);
+		}
+	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepository.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.juwoong.opiniontrade.survey.domain.Survey;
 
-public interface SurveyRepository extends JpaRepository<Survey, Long> {
+public interface SurveyRepository extends JpaRepository<Survey, Long>, SurveyRepositoryCustom {
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustom.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustom.java
@@ -9,5 +9,5 @@ import com.juwoong.opiniontrade.survey.domain.Survey;
 
 public interface SurveyRepositoryCustom {
 
-	Slice<Survey> getSurveysByCursor(Long cursorId, LocalDateTime time, Pageable pageable);
+	Slice<Survey> getSurveysByCursor(Long userId, Long cursorId, LocalDateTime time, Pageable pageable);
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustom.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.juwoong.opiniontrade.survey.domain.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.juwoong.opiniontrade.survey.domain.Survey;
+
+public interface SurveyRepositoryCustom {
+
+	Slice<Survey> getSurveysByCursor(Long cursorId, LocalDateTime time, Pageable pageable);
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustomImpl.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustomImpl.java
@@ -3,7 +3,6 @@ package com.juwoong.opiniontrade.survey.domain.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -21,9 +20,12 @@ public class SurveyRepositoryCustomImpl implements SurveyRepositoryCustom {
 	private QSurvey qSurvey = QSurvey.survey;
 
 	@Override
-	public Slice<Survey> getSurveysByCursor(Long cursorId, LocalDateTime time, Pageable pageable) {
+	public Slice<Survey> getSurveysByCursor(Long userId, Long cursorId, LocalDateTime time, Pageable pageable) {
 		List<Survey> surveys = queryFactory.selectFrom(qSurvey)
-			.where(cursor(cursorId, time))
+			.where(
+				qSurvey.creator.creatorId.eq(userId)
+					.and(cursor(cursorId, time))
+			)
 			.orderBy(qSurvey.updatedAt.desc(), qSurvey.id.asc())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustomImpl.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package com.juwoong.opiniontrade.survey.domain.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import com.juwoong.opiniontrade.survey.domain.QSurvey;
+import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SurveyRepositoryCustomImpl implements SurveyRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private QSurvey qSurvey = QSurvey.survey;
+
+	@Override
+	public Slice<Survey> getSurveysByCursor(Long cursorId, LocalDateTime time, Pageable pageable) {
+		List<Survey> surveys = queryFactory.selectFrom(qSurvey)
+			.where(cursor(cursorId, time))
+			.orderBy(qSurvey.updatedAt.desc(), qSurvey.id.asc())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = surveys.size() == pageable.getPageSize() + 1;
+		if (hasNext)
+			surveys.remove(pageable.getPageSize());
+
+		return new SliceImpl<Survey>(surveys, pageable, hasNext);
+	}
+
+	private BooleanExpression cursor(Long cursorId, LocalDateTime time) {
+		return qSurvey.updatedAt.lt(time)
+			.or(qSurvey.updatedAt.eq(time).and(qSurvey.id.gt(cursorId)));
+	}
+}

--- a/src/test/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/domain/repository/SurveyRepositoryTest.java
@@ -76,11 +76,13 @@ class SurveyRepositoryTest {
 		surveyRepository.save(survey4);
 
 		// 첫번째 페이징 조회 + 디폴트 값
+		Long creatorId = 1L;
 		Long defaultCursorId = 0L;
 		LocalDateTime defaultCursorDate = LocalDateTime.now();
 		Pageable pageable = PageRequest.of(0, 2);
 
 		Slice<Survey> surveys = surveyRepository.getSurveysByCursor(
+			creatorId,
 			defaultCursorId,
 			defaultCursorDate,
 			pageable
@@ -89,6 +91,7 @@ class SurveyRepositoryTest {
 		// 두번째 페이징 조회 + 이전 페이징 결과의 마지막 설문지
 		Survey pagingLastSurvey = surveys.getContent().get(1);
 		Slice<Survey> surveys2 = surveyRepository.getSurveysByCursor(
+			creatorId,
 			pagingLastSurvey.getId(),
 			pagingLastSurvey.getUpdatedAt(),
 			pageable


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 작성자가 생성한 설문지 전체조회 기능을 구현했습니다.
<img width="993" alt="스크린샷 2024-03-19 오후 11 08 50" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/14f87c32-578d-4142-844e-67e30a33aa58">

## 👨‍👩‍👦‍👦 주요 작업 설명
- offset 기반 페이징을 구현하려 했지만 학습목적으로 동적쿼리를 사용해 커서기반 페이징을 구현했습니다.
- 업데이트 날짜 내림차순 페이징을 구현했습니다. 

```
Select *
From survey
Where creatorId = userId
And { survey.updateDate < {cursorDate}
       	   	or 
		{survey.updateDate  = {cursorDate}
            		and
		surveyId> {cursorId}
		}
	}
orderBy updateDate desc, surveyId ask
Limit size;
```

## 👨‍👩‍👧‍👧 기타 의견 
- slice 반환값에 대해선 프론트를 구현해보고 판단할 예정입니다.
- 쿼리DSL 사용, 커서기반 페이징 적용에 의의를 두며, 필터 기능 적용 후 조회 기능 리팩터링할 것입니다.
- or을 사용하는한 커서 기반 페이징으로 큰 효과를 가지지는 않는 것 같습니다. 리팩터링시 성능개선도 함꼐 할 것입니다.  
