### PR TITLE
응답자별 설문 응답 조회 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
+++ b/src/main/java/com/juwoong/opiniontrade/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+	// 400
+	INDEX_OUT_OF_BOUNDS(BAD_REQUEST, "범위에 없는 값을 요청했습니다."),
 	// 404
 	NOT_FOUND_SURVEY(NOT_FOUND, "설문지가 존재하지 않습니다."),
 	NOT_FOUND_SURVEY_RESULT(NOT_FOUND, "설문 결과가 존재하지 않습니다.");

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -3,16 +3,19 @@ package com.juwoong.opiniontrade.survey.api;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyResultService;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,4 +48,13 @@ public class SurveyResultController {
 
 		surveyResultService.updateSurveyResult(surveyId, respondentId, answers);
 	}
+	@GetMapping("/{surveyId}/surveyResult/byRespondent")
+	@ResponseStatus(HttpStatus.OK)
+	public SurveyResultResponse.GetByRespondent getSurveyResultByRespondent(
+		@PathVariable Long surveyId,
+		@RequestParam(defaultValue = "0") Integer nextRespondent
+	){
+		return surveyResultService.getSurveyResultByRespondent(surveyId, nextRespondent);
+	}
+
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.opiniontrade.global.exception.OpinionTradeException;
 import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
+import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
 import com.juwoong.opiniontrade.survey.domain.Answer;
 import com.juwoong.opiniontrade.survey.domain.Respondent;
 import com.juwoong.opiniontrade.survey.domain.Survey;
@@ -45,6 +46,17 @@ public class SurveyResultService {
 			.toList();
 
 		survey.updateSurveyResult(respondentId, answers);
+	}
+
+	public SurveyResultResponse.GetByRespondent getSurveyResultByRespondent(Long surveyId, Integer index) {
+		Survey survey = findSurveyById(surveyId);
+		Integer totalSurveyResultSize = survey.getTotalSurveyResultSize();
+		if (index >= totalSurveyResultSize){
+			throw new OpinionTradeException(INDEX_OUT_OF_BOUNDS);
+		}
+		SurveyResult surveyResult = survey.getSurveyResultByRespondent(index);
+
+		return new SurveyResultResponse.GetByRespondent(totalSurveyResultSize, index, surveyResult);
 	}
 
 	private Survey findSurveyById(Long id) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
@@ -1,0 +1,24 @@
+package com.juwoong.opiniontrade.survey.application.response;
+
+import java.util.List;
+
+import com.juwoong.opiniontrade.survey.domain.Answer;
+import com.juwoong.opiniontrade.survey.domain.SurveyResult;
+
+public sealed interface SurveyResultResponse {
+	record GetByRespondent(
+		Integer totalRespondents,
+		Integer currentRespondent,
+		Long respondentId,
+		List<Answer> answers
+	) implements SurveyResultResponse {
+		public GetByRespondent(Integer totalRespondents, Integer currentRespondent, SurveyResult result) {
+			this(
+				totalRespondents,
+				currentRespondent,
+				result.getRespondent().getRespondentId(),
+				result.getAnswers()
+			);
+		}
+	}
+}

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Answer.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Answer.java
@@ -4,8 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+@Getter
 @Embeddable
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -107,8 +107,12 @@ public class Survey extends TimeBaseEntity {
 		result.updateAnswers(answers);
 	}
 
-	public SurveyResult getSurveyResultByRespondent(Respondent respondent) {
-		return null;
+	public Integer getTotalSurveyResultSize(){
+		return surveyResults.size();
+	}
+
+	public SurveyResult getSurveyResultByRespondent(Integer index) {
+		return surveyResults.get(index);
 	}
 
 	void updateSurveyResultAnswer(Respondent respondent, Answer answer) {


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
- 설문지에 응답한 설문 결과를 응답자 기준으로 조회하는 기능을 구현했습니다.
<img width="721" alt="스크린샷 2024-03-20 오전 11 19 43" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/b1a61f77-2e0f-4623-9251-40075b5eebf2">

## 👨‍👩‍👦‍👦 주요 작업 설명
- 반환값에 응답결과 전체갯수와 현재 응답결과 인덱스를 반환합니다.
- 클라이언트는 인덱스 값을 통해 다음 결과를 요청합니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 없음
