### PR TITLE
질문별 설문 응답 조회 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -66,5 +66,4 @@ public class SurveyResultController {
 	) {
 		return surveyResultService.getSurveyResultByQuestion(surveyId, questionId);
 	}
-
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/api/SurveyResultController.java
@@ -48,13 +48,23 @@ public class SurveyResultController {
 
 		surveyResultService.updateSurveyResult(surveyId, respondentId, answers);
 	}
+
 	@GetMapping("/{surveyId}/surveyResult/byRespondent")
 	@ResponseStatus(HttpStatus.OK)
 	public SurveyResultResponse.GetByRespondent getSurveyResultByRespondent(
 		@PathVariable Long surveyId,
 		@RequestParam(defaultValue = "0") Integer nextRespondent
-	){
+	) {
 		return surveyResultService.getSurveyResultByRespondent(surveyId, nextRespondent);
+	}
+
+	@GetMapping("/{surveyId}/surveyResult/byQuestion")
+	@ResponseStatus(HttpStatus.OK)
+	public SurveyResultResponse.GetByQuestion getSurveyResponseByQuestion(
+		@PathVariable Long surveyId,
+		@RequestParam Long questionId
+	) {
+		return surveyResultService.getSurveyResultByQuestion(surveyId, questionId);
 	}
 
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/SurveyResultService.java
@@ -51,12 +51,19 @@ public class SurveyResultService {
 	public SurveyResultResponse.GetByRespondent getSurveyResultByRespondent(Long surveyId, Integer index) {
 		Survey survey = findSurveyById(surveyId);
 		Integer totalSurveyResultSize = survey.getTotalSurveyResultSize();
-		if (index >= totalSurveyResultSize){
+		if (index >= totalSurveyResultSize) {
 			throw new OpinionTradeException(INDEX_OUT_OF_BOUNDS);
 		}
 		SurveyResult surveyResult = survey.getSurveyResultByRespondent(index);
 
 		return new SurveyResultResponse.GetByRespondent(totalSurveyResultSize, index, surveyResult);
+	}
+
+	public SurveyResultResponse.GetByQuestion getSurveyResultByQuestion(Long surveyId, Long questionId) {
+		Survey survey = findSurveyById(surveyId);
+		List<Answer> answers = survey.getSurveyResultByQuestion(questionId);
+
+		return new SurveyResultResponse.GetByQuestion(questionId, answers);
 	}
 
 	private Survey findSurveyById(Long id) {

--- a/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/application/response/SurveyResultResponse.java
@@ -21,4 +21,11 @@ public sealed interface SurveyResultResponse {
 			);
 		}
 	}
+
+	record GetByQuestion(
+		Long questionId,
+		List<Answer> answers
+	) implements SurveyResultResponse {
+	}
+
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/Survey.java
@@ -107,7 +107,7 @@ public class Survey extends TimeBaseEntity {
 		result.updateAnswers(answers);
 	}
 
-	public Integer getTotalSurveyResultSize(){
+	public Integer getTotalSurveyResultSize() {
 		return surveyResults.size();
 	}
 
@@ -115,6 +115,11 @@ public class Survey extends TimeBaseEntity {
 		return surveyResults.get(index);
 	}
 
-	void updateSurveyResultAnswer(Respondent respondent, Answer answer) {
+	public List<Answer> getSurveyResultByQuestion(Long questionId) {
+		return surveyResults.stream()
+			.map(surveyResult -> surveyResult.getAnswerByQuestionId(questionId))
+			.filter(answer -> answer.isPresent())
+			.map(answer -> answer.get())
+			.toList();
 	}
 }

--- a/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
+++ b/src/main/java/com/juwoong/opiniontrade/survey/domain/SurveyResult.java
@@ -1,6 +1,7 @@
 package com.juwoong.opiniontrade.survey.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.juwoong.opiniontrade.global.entity.TimeBaseEntity;
 
@@ -45,4 +46,9 @@ public class SurveyResult extends TimeBaseEntity {
 		this.answers = answers;
 	}
 
+	public Optional<Answer> getAnswerByQuestionId(Long questionId) {
+		return answers.stream()
+			.filter(answer -> answer.getQuestionId().equals(questionId))
+			.findFirst();
+	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/api/SurveyResultControllerTest.java
@@ -19,9 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.juwoong.opiniontrade.survey.api.request.ResultRequest;
 import com.juwoong.opiniontrade.survey.application.SurveyResultService;
 import com.juwoong.opiniontrade.survey.application.response.SurveyResultResponse;
-import com.juwoong.opiniontrade.survey.domain.Survey;
+import com.juwoong.opiniontrade.survey.domain.Answer;
 import com.juwoong.opiniontrade.survey.domain.SurveyResult;
-import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
 import com.juwoong.opiniontrade.survey.fixture.SurveyResultFixture;
 
 @WebMvcTest(SurveyResultController.class)
@@ -103,5 +102,38 @@ class SurveyResultControllerTest {
 			.andExpect(jsonPath("$.respondentId").value(surveyResult.getRespondent().getRespondentId()))
 			.andExpect(jsonPath("$.answers[0].questionId").value(surveyResult.getAnswers().get(0).getQuestionId()))
 			.andExpect(jsonPath("$.answers[0].content").value(surveyResult.getAnswers().get(0).getContent()));
+	}
+
+	@Test
+	@DisplayName("질문 기준 설문 결과 조회시 200 상태 코드와 반환값을 응답 한다")
+	void getSurveyResultByQuestion_Success() throws Exception {
+		// given
+		Long surveyId = 1L;
+		Long questionId = 1L;
+
+		List<Answer> answers = List.of(
+			Answer.init(questionId, "contents"),
+			Answer.init(questionId, "contents")
+		);
+
+		SurveyResultResponse.GetByQuestion response = new SurveyResultResponse.GetByQuestion(questionId,
+			answers);
+
+		when(surveyResultService.getSurveyResultByQuestion(anyLong(), anyLong())).thenReturn(response);
+
+		// when
+		ResultActions result = mockMvc.perform(
+			get("/surveys/{surveyId}/surveyResult/byQuestion", surveyId)
+				.param("questionId", questionId.toString())
+				.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.questionId").value(questionId))
+			.andExpect(jsonPath("$.answers[0].questionId").value(answers.get(0).getQuestionId()))
+			.andExpect(jsonPath("$.answers[0].content").value(answers.get(0).getContent()))
+			.andExpect(jsonPath("$.answers[1].questionId").value(answers.get(1).getQuestionId()))
+			.andExpect(jsonPath("$.answers[1].content").value(answers.get(1).getContent()));
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/application/SurveyResultServiceTest.java
@@ -97,4 +97,28 @@ class SurveyResultServiceTest {
 			.isInstanceOf(OpinionTradeException.class)
 			.hasMessageContaining("범위에 없는 값을 요청했습니다.");
 	}
+
+	@Test
+	@DisplayName("질문별 설문 결과 조회에 성공한다.")
+	void getSurveyResultByQuestion_Success() {
+		// given
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		List<SurveyResult> results = List.of(
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_ONE.getInstance(),
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_ONE.getInstance(),
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_TWO.getInstance()
+		);
+		results.forEach(surveyResult -> survey.receiveSurveyResult(surveyResult));
+		when(surveyRepository.findById(anyLong())).thenReturn(Optional.of(survey));
+
+		// when
+		SurveyResultResponse.GetByQuestion response = surveyResultService.getSurveyResultByQuestion(1L, 1L);
+
+		// then
+		assertAll(
+			() -> assertThat(response.answers().size()).isEqualTo(2),
+			() -> assertThat(response.answers().get(0).getQuestionId()).isEqualTo(1L),
+			() -> assertThat(response.answers().get(1).getQuestionId()).isEqualTo(1L)
+		);
+	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/domain/SurveyTest.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/domain/SurveyTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import com.juwoong.opiniontrade.survey.fixture.QuestionFixture;
 import com.juwoong.opiniontrade.survey.fixture.SurveyFixture;
+import com.juwoong.opiniontrade.survey.fixture.SurveyResultFixture;
 
 class SurveyTest {
 	@Test
@@ -30,5 +31,24 @@ class SurveyTest {
 
 		// then
 		assertThat(survey.getQuestions().get(2).getType().name()).isEqualTo(MULTIPLE_CHOICE.name());
+	}
+
+	@Test
+	@DisplayName("질문 아이디에 대한 설문 결과의 응답 내용을 가져올 수 있다")
+	void getAnswers_About_Question_Form_SurveyResults_In_Survey() {
+		// given
+		Survey survey = SurveyFixture.SURVEY.getInstance();
+		List<SurveyResult> results = List.of(
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_ONE.getInstance(),
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_ONE.getInstance(),
+			SurveyResultFixture.SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_TWO.getInstance()
+		);
+		results.forEach(surveyResult -> survey.receiveSurveyResult(surveyResult));
+
+		// when
+		List<Answer> answers = survey.getSurveyResultByQuestion(1L);
+
+		// then
+		assertThat(answers.size()).isEqualTo(2);
 	}
 }

--- a/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyResultFixture.java
+++ b/src/test/java/com/juwoong/opiniontrade/survey/fixture/SurveyResultFixture.java
@@ -7,7 +7,9 @@ import com.juwoong.opiniontrade.survey.domain.Respondent;
 import com.juwoong.opiniontrade.survey.domain.SurveyResult;
 
 public enum SurveyResultFixture {
-	SURVEY_RESULT(1l, 1l, "content");
+	SURVEY_RESULT(1l, 1l, "content"),
+	SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_ONE(1l, 1l, "content"),
+	SURVEY_RESULT_WITH_ANSWER_FOR_QUESTION_ID_TWO(1l, 2l, "content");
 	private Long respondentId;
 	private Long questionId;
 	private String answerContent;


### PR DESCRIPTION
## 👨‍👩‍👧‍👦 PR 설명
-  질문을 기준으로 설문 결과의 응답내용을 모아보는 기능을 구현했습니다.
<img width="804" alt="스크린샷 2024-03-20 오후 2 04 18" src="https://github.com/JuwoongKim/opinion-trade/assets/62009283/58bd8377-e478-4363-babf-e670b62210c2">

## 👨‍👩‍👦‍👦 주요 작업 설명
- 질문번호를 입력받아 설문 결과에서 질문번호에 대한 답변내용을 추출해 리스트로 응답합니다.

## 👨‍👩‍👧‍👧 기타 의견 
- 없음
